### PR TITLE
fix: support more test super classes

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -58,7 +58,7 @@ function NeotestAdapter.discover_positions(file_path)
     ((
         class
         name: (constant) @namespace.name
-        (superclass (scope_resolution) @superclass (#match? @superclass "(ActionDispatch::IntegrationTest|ActiveSupport::TestCase)$"))
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase)$"))
     )) @namespace.definition
 
     ((


### PR DESCRIPTION
I found that I was missing some test superclasses. This less restrictive regex seems to add the ones I need and feels fairly safe regarding how less specific it is.

For example, I have tests that use `ActionMailer::TestCase`.

Fixes #4.