### PR TITLE
fix: prevent crash when no pos_id in current file

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -148,9 +148,10 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
 
   for test_name, status in string.gmatch(output, test_pattern) do
     local pos_id = name_mappings[test_name]
-    results[pos_id] = {
+
+    if pos_id then results[pos_id] = {
       status = status == "." and "passed" or "failed",
-    }
+    } end
   end
 
   for test_name, filepath, expected, actual in string.gmatch(output, failure_pattern) do


### PR DESCRIPTION
I often include some tests in a file via an included Rails concern. A common situation is a shared test that asserts all fixtures for the given model are valid. The problem I'm running into is those tests are not in the `name_mappings` table because they are not in the current test file. So when it gets to match the results to names here it crashes because `pos_id` is `nil`.

This may be a unique situation to my apps but I think not crashing on the nil is a valid solution regardless of how I'm hitting it.

Also, this is part 1 of the fix. If this test fails I can see it in the output panel but it doesn't show in summary panel or a popover. One potential fix that I'll explore next is putting the failure on the test class itself. Or even the include line if I can make that work.

Here is an example test:

```ruby

module AssertValidFixtures
  extend ActiveSupport::Concern

  included do
    test "fixtures are valid" do
      described_class.all.each do |fixture|
        assert_predicate fixture,
                         :valid?,
                         "#{fixture} - #{fixture.errors.full_messages.to_sentence}"
      end
    end

    def described_class
      self.class.name.gsub(/Test($|::)/, "\\1").constantize
    end

  end
end

```