### PR TITLE
Escape ? in test names

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -90,11 +90,11 @@ function NeotestAdapter.build_spec(args)
   end
 
   local function run_by_name()
-    local full_name = utils.full_test_name(args.tree, position.name)
+    local full_name = utils.escaped_full_test_name(args.tree, position.name)
     table.insert(script_args, position.path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
-    table.insert(script_args, "/" .. full_name:gsub("%#", "\\#") .. "/")
+    table.insert(script_args, "/" .. full_name .. "/")
   end
 
   local function run_dir()

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -42,6 +42,11 @@ M.full_test_name = function(tree)
   return parent_name .. "#" .. name:gsub(" ", "_")
 end
 
+M.escaped_full_test_name = function(tree)
+  local full_name = M.full_test_name(tree)
+  return full_name:gsub("([?#])", "\\%1")
+end
+
 M.get_mappings = function(tree)
   -- get the mappings for the current node and its children
   local mappings = {}

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -68,6 +68,38 @@ describe("full_test_name", function()
   end)
 end)
 
+describe("escaped_full_test_name", function()
+  it("escapes # characters", function()
+    local tree = Tree.from_list({
+      { id = "namespace", name = "namespace", type = "namespace" },
+      { id = "test", name = "#escaped_full_test_name should be escaped" },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals("namespace\\#test_\\#escaped_full_test_name_should_be_escaped", utils.escaped_full_test_name(tree:children()[1]))
+  end)
+
+  it("escapes ? characters", function()
+    local tree = Tree.from_list({
+      { id = "namespace", name = "namespace", type = "namespace" },
+      { id = "test", name = "escaped? should be escaped" },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals("namespace\\#test_escaped\\?_should_be_escaped", utils.escaped_full_test_name(tree:children()[1]))
+  end)
+
+  it("escapes multiple ? and # characters", function()
+    local tree = Tree.from_list({
+      { id = "namespace", name = "namespace", type = "namespace" },
+      { id = "test", name = "#escaped? should be escaped" },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals("namespace\\#test_\\#escaped\\?_should_be_escaped", utils.escaped_full_test_name(tree:children()[1]))
+  end)
+end)
+
 describe("get_mappings", function()
   it("gives full test name for nodes of tree", function()
     local tree = Tree.from_list({


### PR DESCRIPTION
Hey, thanks for the great work on the plugin!

I noticed that tests weren't being run if they contained `?` in their descriptions (when running with `require("neotest").run.run()" at least, because mini test needs `?` to be escaped. I saw that `#` is already escaped by the plugins, so I've added `?` to the gsub call. I extracted a method so I could test it as I'm not familiar with Lua and wanted to make sure I wasn't making mistakes.