### PR TITLE
Modify filter_dir to only exclude "vendor"

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -30,9 +30,7 @@ end
 ---@param root string Root directory of project
 ---@return boolean
 function NeotestAdapter.filter_dir(name, rel_path, root)
-  local _, count = rel_path:gsub("/", "")
-  if rel_path:match("test") or count < 1 then return true end
-  return false
+  return name ~= "vendor"
 end
 
 ---Given a file path, parse all the tests within it.

--- a/tests/adapter/plugin_spec.lua
+++ b/tests/adapter/plugin_spec.lua
@@ -11,9 +11,6 @@ describe("is_test_file", function()
 end)
 
 describe("filter_dir", function()
-  -- note that even though these tests suggest that `engine/things/spec` would be approved,
-  -- `engine/things` would return false, so `engine/things/spec` would never be searched by
-  -- neotest
   local root = "/home/name/projects"
   it("allows test", function()
     assert.equals(true, plugin.filter_dir("test", "test", root))
@@ -27,7 +24,10 @@ describe("filter_dir", function()
   it("allows a long path with test at the start", function()
     assert.equals(true, plugin.filter_dir("billing_service", "test/controllers/billing_service", root))
   end)
-  it("disallows paths without test, more that one sub dir deep", function()
-    assert.equals(false, plugin.filter_dir("models", "app/models", root))
+  it("allows paths without test, more that one sub dir deep", function()
+    assert.equals(true, plugin.filter_dir("models", "app/models", root))
+  end)
+  it("disallows the vendor directory", function()
+    assert.equals(false, plugin.filter_dir("vendor", "vendor", root))
   end)
 end)


### PR DESCRIPTION
Closes #13 

This changed the `filter_dir` to exclude only the vendor directory. The logic being that it is filtering out this directory because it may contains test files that should be ignored by the plugin.

This change will mean that tests in nested directories that would previously have been ignored are now correctly picked up.