### PR TITLE
Add support for testing inside modules

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -124,9 +124,9 @@ end
 
 function NeotestAdapter._parse_test_output(output, name_mappings)
   local results = {}
-  local test_pattern = "(%w+#[%S]+)%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
+  local test_pattern = "([a-zA-Z0-9:]+#[%S]+)%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
   local failure_pattern = "Failure:%s*([%w#_]+)%s*%[([^%]]+)%]:%s*Expected:%s*(.-)%s*Actual:%s*(.-)%s\n\n"
-  local error_pattern = "Error:%s*([%w#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
+  local error_pattern = "Error:%s*([%w:#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
   local traceback_pattern = "(%d+:[^:]+:%d+:in `[^']+')%s+([^:]+):(%d+):(in `[^']+':[^\n]+)"
 
   for last_traceback, file_name, line_str, message in string.gmatch(output, traceback_pattern) do

--- a/tests/adapter/rails_integration_spec.lua
+++ b/tests/adapter/rails_integration_spec.lua
@@ -36,6 +36,7 @@ describe("Rails Integration Test", function()
       assert.are.same(positions, expected_positions)
     end)
   end)
+
   describe("_parse_test_output", function()
     describe("single passing test", function()
       local output = [[
@@ -45,6 +46,36 @@ UserControllerTest#test_is_site-admin = 0.25 s = .
         local results = plugin._parse_test_output(output, { ["UserControllerTest#test_is_site-admin"] = "testing" })
 
         assert.are.same({ ["testing"] = { status = "passed" } }, results)
+      end)
+    end)
+
+    -- UserOnboarding::UserControllerTest#test_should_get_update = 0.25 s = E
+    describe("single error test", function()
+      local output = [[
+CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit = 0.00 s = E
+
+
+Error:
+CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit:
+NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest
+    test/controllers/caregiver_onboarding/user_info_controller_test.rb:5:in `block in <class:UserInfoControllerTest>'
+      ]]
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(
+          output,
+          { ["CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit"] = "testing" }
+        )
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              {
+                line = 4,
+                message = "NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest",
+              },
+            },
+          },
+        }, results)
       end)
     end)
   end)


### PR DESCRIPTION
Currently, tests inside module or tests that cover controllers (or similar) inside modules don't parse correctly and end up in "skipped" state. This adds checks for `:` to the `test_pattern` and `error_pattern` to support those cases.