### PR TITLE
Further support for tests inside modules

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -65,7 +65,7 @@ function NeotestAdapter.discover_positions(file_path)
           (constant) @namespace.name
           (scope_resolution scope: (constant) name: (constant) @namespace.name)
         ]
-        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase)$"))
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
     )) @namespace.definition
 
     ((

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -61,8 +61,11 @@ function NeotestAdapter.discover_positions(file_path)
     ; rails unit classes
     ((
         class
-        name: (constant) @namespace.name
-        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
+        name: [
+          (constant) @namespace.name
+          (scope_resolution scope: (constant) name: (constant) @namespace.name)
+        ]
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase)$"))
     )) @namespace.definition
 
     ((
@@ -129,8 +132,8 @@ end
 
 function NeotestAdapter._parse_test_output(output, name_mappings)
   local results = {}
-  local test_pattern = "([a-zA-Z0-9:]+#[%S]+)%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
-  local failure_pattern = "Failure:%s*([%w#_]+)%s*%[([^%]]+)%]:%s*Expected:%s*(.-)%s*Actual:%s*(.-)%s"
+  local test_pattern = "(%w+#[%S]+)%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
+  local failure_pattern = "Failure:%s*([%w#_:]+)%s*%[([^%]]+)%]:%s*Expected:%s*(.-)%s*Actual:%s*(.-)%s"
   local error_pattern = "Error:%s*([%w:#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
   local traceback_pattern = "(%d+:[^:]+:%d+:in `[^']+')%s+([^:]+):(%d+):(in `[^']+':[^\n]+)"
 
@@ -156,8 +159,9 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
       status = status == "." and "passed" or "failed",
     } end
   end
-
   for test_name, filepath, expected, actual in string.gmatch(output, failure_pattern) do
+    test_name = utils.replace_module_namespace(test_name)
+
     local line = tonumber(string.match(filepath, ":(%d+)$"))
     local message = string.format("Expected: %s\n  Actual: %s", expected, actual)
     local pos_id = name_mappings[test_name]
@@ -174,6 +178,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
   end
 
   for test_name, message, line_str in string.gmatch(output, error_pattern) do
+    test_name = utils.replace_module_namespace(test_name)
     local line = tonumber(line_str)
     local pos_id = name_mappings[test_name]
     if results[pos_id] then

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -18,6 +18,16 @@ local function replace_paths(str, what, with)
   return string.gsub(str, what, with)
 end
 
+-- We are considering test class names without their module, but
+-- Lua's built-in pattern matching isn't powerful enough to do so. Instead
+-- we match on the full name, including module, and strip it off here.
+--
+-- @param test_name string
+-- @return string
+M.replace_module_namespace = function(test_name)
+  return test_name.gsub(test_name, "%w+::", "")
+end
+
 ---@param position neotest.Position The position to return an ID for
 ---@param namespace neotest.Position[] Any namespaces the position is within
 ---@return string

--- a/tests/adapter/rails_integration_spec.lua
+++ b/tests/adapter/rails_integration_spec.lua
@@ -36,7 +36,6 @@ describe("Rails Integration Test", function()
       assert.are.same(positions, expected_positions)
     end)
   end)
-
   describe("_parse_test_output", function()
     describe("single passing test", function()
       local output = [[
@@ -46,36 +45,6 @@ UserControllerTest#test_is_site-admin = 0.25 s = .
         local results = plugin._parse_test_output(output, { ["UserControllerTest#test_is_site-admin"] = "testing" })
 
         assert.are.same({ ["testing"] = { status = "passed" } }, results)
-      end)
-    end)
-
-    -- UserOnboarding::UserControllerTest#test_should_get_update = 0.25 s = E
-    describe("single error test", function()
-      local output = [[
-CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit = 0.00 s = E
-
-
-Error:
-CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit:
-NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest
-    test/controllers/caregiver_onboarding/user_info_controller_test.rb:5:in `block in <class:UserInfoControllerTest>'
-      ]]
-      it("parses the results correctly", function()
-        local results = plugin._parse_test_output(
-          output,
-          { ["CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit"] = "testing" }
-        )
-        assert.are.same({
-          ["testing"] = {
-            status = "failed",
-            errors = {
-              {
-                line = 4,
-                message = "NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest",
-              },
-            },
-          },
-        }, results)
       end)
     end)
   end)

--- a/tests/adapter/rails_module_spec.lua
+++ b/tests/adapter/rails_module_spec.lua
@@ -2,6 +2,7 @@ local plugin = require("neotest-minitest")
 local async = require("nio.tests")
 
 describe("Rails Module Test", function()
+  assert:set_parameter("TableFormatLevel", -1)
   describe("discover_positions", function()
     async.it("should discover the position for the tests", function()
       local test_path = vim.loop.cwd() .. "/tests/minitest_examples/rails_module_test.rb"
@@ -101,7 +102,7 @@ Expected: 2
         local results = plugin._parse_test_output(output, { ["UserInfoControllerTest#test_throwaway"] = "testing" })
 
         assert.are.same({
-          ["testing"] = { status = "failed", errors = { { message = "Expected: 2\n  Actual: 4", line = 21 } } },
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 2\n  Actual: 4", line = 20 } } },
         }, results)
       end)
     end)

--- a/tests/adapter/rails_module_spec.lua
+++ b/tests/adapter/rails_module_spec.lua
@@ -1,0 +1,109 @@
+local plugin = require("neotest-minitest")
+local async = require("nio.tests")
+
+describe("Rails Module Test", function()
+  describe("discover_positions", function()
+    async.it("should discover the position for the tests", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/rails_module_test.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "rails_module_test.rb",
+          path = test_path,
+          range = { 0, 0, 21, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/rails_module_test.rb::18",
+            name = "FooControllerTest",
+            path = test_path,
+            range = { 17, 0, 20, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/rails_module_test.rb::19",
+              name = "should pass",
+              path = test_path,
+              range = { 18, 2, 19, 5 },
+              type = "test",
+            },
+          },
+        },
+      }
+      assert.are.same(expected_positions, positions)
+    end)
+  end)
+  describe("_parse_test_output", function()
+    describe("single error test", function()
+      local output = [[
+CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit = 0.00 s = E
+
+
+Error:
+CaregiverOnboarding::UserInfoControllerTest#test_should_get_edit:
+NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest
+    test/controllers/caregiver_onboarding/user_info_controller_test.rb:5:in `block in <class:UserInfoControllerTest>'
+      ]]
+      it("parses the results correctly", function()
+        local results =
+          plugin._parse_test_output(output, { ["UserInfoControllerTest#test_should_get_edit"] = "testing" })
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              {
+                line = 4,
+                message = "NameError: undefined local variable or method `foobar' for an instance of CaregiverOnboarding::UserInfoControllerTest",
+              },
+            },
+          },
+        }, results)
+      end)
+    end)
+
+    describe("multiple passing tests", function()
+      local output = [[
+Foo::RailsUnitTest#test_subtracts_two_numbers = 0.00 s = .
+Foo::RailsUnitTest#test_adds_two_numbers = 0.00 s = .
+    ]]
+
+      it("parses the results correctly", function()
+        -- We end up only parsing the class name, not the module
+        local results = plugin._parse_test_output(output, {
+          ["RailsUnitTest#test_adds_two_numbers"] = "testing",
+          ["RailsUnitTest#test_subtracts_two_numbers"] = "testing2",
+        })
+
+        assert.are.same({
+          ["testing"] = { status = "passed" },
+          ["testing2"] = { status = "passed" },
+        }, results)
+      end)
+    end)
+
+    describe("single failing test", function()
+      local output = [[
+CaregiverOnboarding::UserInfoControllerTest#test_throwaway = 0.07 s = F
+
+
+Failure:
+CaregiverOnboarding::UserInfoControllerTest#test_throwaway [test/controllers/caregiver_onboarding/user_info_controller_test.rb:21]:
+Expected: 2
+  Actual: 4
+
+
+    ]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, { ["UserInfoControllerTest#test_throwaway"] = "testing" })
+
+        assert.are.same({
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 2\n  Actual: 4", line = 21 } } },
+        }, results)
+      end)
+    end)
+  end)
+end)

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -76,7 +76,10 @@ describe("escaped_full_test_name", function()
     }, function(pos)
       return pos.id
     end)
-    assert.equals("namespace\\#test_\\#escaped_full_test_name_should_be_escaped", utils.escaped_full_test_name(tree:children()[1]))
+    assert.equals(
+      "namespace\\#test_\\#escaped_full_test_name_should_be_escaped",
+      utils.escaped_full_test_name(tree:children()[1])
+    )
   end)
 
   it("escapes ? characters", function()
@@ -132,5 +135,13 @@ describe("strip_ansi", function()
     local input = "This is \27[32mgreen\27[0m text!"
 
     assert.equals("This is green text!", utils.strip_ansi_escape_codes(input))
+  end)
+end)
+
+describe("replace_module_namespace", function()
+  it("removes module namespace", function()
+    local input = "Foo::Bar"
+
+    assert.equals("Bar", utils.replace_module_namespace(input))
   end)
 end)

--- a/tests/minitest_examples/rails_module_test.rb
+++ b/tests/minitest_examples/rails_module_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "active_support/message_encryptor"
+require "active_support/dependencies/autoload"
+require "active_support/test_case"
+require "action_controller/template_assertions"
+require "action_dispatch/http/mime_type"
+require "action_dispatch/testing/assertions"
+require "action_dispatch/testing/test_process"
+require "action_dispatch/testing/request_encoder"
+require "action_dispatch/routing"
+require "action_dispatch/testing/integration"
+
+module FooController
+end
+
+class FooController::FooControllerTest < ActionDispatch::IntegrationTest
+  test "should pass" do
+  end
+end


### PR DESCRIPTION
1. Update`discover_positions` to match test name to just the part without the module. So

    ```
    FooBarModule::BazControllerTest
    ```
    
    gives `@namespace.name` of `BazControllerTest`
2. Revert change to `test_pattern` from cf5b217d95fd558bb9d87a350b46c6584e350a7b so that we match the result from 1
3. For `error_pattern` and `failure_pattern`, match the full test name (e.g. `FooBarModule::BazControllerTest`) and then splice the module (e.g. `FooBarModule::`) off. Doesn't seem like Lua pattern matching is powerful enough to do it all in one go, or at least I couldn't figure out how.
4. Move test cases related to this into its own file
