### PR TITLE
Fix parsing failures for diagnostics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.6)
     minitest (5.18.0)
     minitest-rails (7.0.0)
       minitest (~> 5.10)
@@ -39,7 +40,8 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    nokogiri (1.14.3-arm64-darwin)
+    nokogiri (1.14.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.2)
     rack (2.2.6.4)
@@ -66,6 +68,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-23
 
 DEPENDENCIES
   minitest

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -125,7 +125,7 @@ end
 function NeotestAdapter._parse_test_output(output, name_mappings)
   local results = {}
   local test_pattern = "([a-zA-Z0-9:]+#[%S]+)%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
-  local failure_pattern = "Failure:%s*([%w#_]+)%s*%[([^%]]+)%]:%s*Expected:%s*(.-)%s*Actual:%s*(.-)%s\n\n"
+  local failure_pattern = "Failure:%s*([%w#_]+)%s*%[([^%]]+)%]:%s*Expected:%s*(.-)%s*Actual:%s*(.-)%s"
   local error_pattern = "Error:%s*([%w:#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
   local traceback_pattern = "(%d+:[^:]+:%d+:in `[^']+')%s+([^:]+):(%d+):(in `[^']+':[^\n]+)"
 
@@ -162,7 +162,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
       results[pos_id].errors = {
         {
           message = message,
-          line = line,
+          line = line - 1,
         },
       }
     end

--- a/tests/adapter/classic_spec.lua
+++ b/tests/adapter/classic_spec.lua
@@ -41,6 +41,21 @@ describe("Classic Test", function()
 
   describe("_parse_test_output", function()
     assert:set_parameter("TableFormatLevel", -1)
+
+    describe("single assert_equal failure, output from file", function()
+      local output_file_path = "tests/outputs/assert_equal_failure.txt"
+      local f = assert(io.open(output_file_path, "r"))
+      local output = f:read("*all")
+      f.close()
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, { ["UserInfoControllerTest#test_throwaway"] = "testing" })
+
+        assert.are.same({
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 2\n  Actual: 3", line = 20 } } },
+        }, results)
+      end)
+    end)
+
     describe("single failing test", function()
       local output = [[
 ClassicTest#test_addition = 0.00 s = F
@@ -58,7 +73,7 @@ Expected: 3
         local results = plugin._parse_test_output(output, { ["ClassicTest#test_addition"] = "testing" })
 
         assert.are.same({
-          ["testing"] = { status = "failed", errors = { { message = "Expected: 3\n  Actual: 2", line = 7 } } },
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 3\n  Actual: 2", line = 6 } } },
         }, results)
       end)
     end)
@@ -185,7 +200,7 @@ ClassicTest#test_addition = 0.00 s = .
         assert.are.same({
           ["testing_subtraction"] = {
             status = "failed",
-            errors = { { message = "Expected: 1\n  Actual: 0", line = 10 } },
+            errors = { { message = "Expected: 1\n  Actual: 0", line = 9 } },
           },
           ["testing_addition"] = { status = "passed" },
         }, results)
@@ -227,11 +242,11 @@ rails test Users/abry/src/nvim-neotest/neotest-minitest/tests/minitest_examples/
       assert.are.same({
         ["testing_addition"] = {
           status = "failed",
-          errors = { { message = "Expected: 5\n  Actual: 2", line = 7 } },
+          errors = { { message = "Expected: 5\n  Actual: 2", line = 6 } },
         },
         ["testing_subtraction"] = {
           status = "failed",
-          errors = { { message = "Expected: 1\n  Actual: 0", line = 10 } },
+          errors = { { message = "Expected: 1\n  Actual: 0", line = 9 } },
         },
       }, results)
     end)

--- a/tests/adapter/rails_unit_spec.lua
+++ b/tests/adapter/rails_unit_spec.lua
@@ -65,7 +65,7 @@ Expected: 4
         local results = plugin._parse_test_output(output, { ["RailsUnitTest#test_adds_two_numbers"] = "testing" })
 
         assert.are.same(
-          { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 8 } } } },
+          { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } } },
           results
         )
       end)
@@ -81,11 +81,14 @@ tests/minitest_examples/rails_unit_erroring_test.rb:1:in `require': cannot load 
       it("parses the results correctly", function()
         local results = plugin._parse_test_output(output, { ["RailsUnitErroringTest#test_addition"] = "testing" })
 
-        assert.are.same(
-          {
-            ["testing"] = { status = "failed", errors = {
-              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 } } }
-          }, results)
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+        }, results)
       end)
     end)
 
@@ -99,16 +102,23 @@ tests/minitest_examples/rails_unit_erroring_test.rb:1:in `require': cannot load 
       it("parses the results correctly", function()
         local results = plugin._parse_test_output(output, {
           ["RailsUnitErroringTest#test_addition"] = "testing",
-          ["RailsUnitTest#test_subtracts_two_numbers"] = "testing1"
+          ["RailsUnitTest#test_subtracts_two_numbers"] = "testing1",
         })
 
-        assert.are.same(
-          {
-            ["testing"] = { status = "failed", errors = {
-              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 } } },
-            ["testing1"] = { status = "failed", errors = {
-              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 } } }
-          }, results)
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+          ["testing1"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+        }, results)
       end)
     end)
 
@@ -145,7 +155,7 @@ Expected: 4
         })
 
         assert.are.same({
-          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 8 } } },
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } },
           ["testing2"] = { status = "passed" },
         }, results)
       end)
@@ -181,8 +191,8 @@ Expected: 1
         })
 
         assert.are.same({
-          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 8 } } },
-          ["testing2"] = { status = "failed", errors = { { message = "Expected: 1\n  Actual: 2", line = 11 } } },
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } },
+          ["testing2"] = { status = "failed", errors = { { message = "Expected: 1\n  Actual: 2", line = 10 } } },
         }, results)
       end)
     end)

--- a/tests/outputs/assert_equal_failure.txt
+++ b/tests/outputs/assert_equal_failure.txt
@@ -1,0 +1,20 @@
+Running 3 tests in a single process (parallelization threshold is 50)
+Run options: --name /UserInfoControllerTest\#test_throwaway/ -v --seed 7565
+
+# Running:
+
+UserInfoControllerTest#test_throwaway = 0.07 s = F
+
+
+Failure:
+UserInfoControllerTest#test_throwaway [test/controllers/caregiver_onboarding/user_info_controller_test.rb:21]:
+Expected: 2
+  Actual: 3
+
+
+bin/rails test test/controllers/caregiver_onboarding/user_info_controller_test.rb:20
+
+
+Finished in 0.073849s, 13.5411 runs/s, 13.5411 assertions/s.
+1 runs, 1 assertions, 1 failures, 0 errors, 0 skips
+


### PR DESCRIPTION
For whatever reason, the outputs neotest gives us are in DOS format (\r\n line endings). This is why failures don't show up in diagnostics even though we set errors in the results and tests are passing.

Luckily, it seems we don't need the newlines in `failure_pattern`.

Added a test with a file in DOS format to cover this going forward.

Before
![CleanShot 2024-04-15 at 22 24 18@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/76ad5ca7-ec05-4624-9ad6-bdfb9f90e845)

After
![CleanShot 2024-04-15 at 22 24 49@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/5e86621e-2de6-4fdb-aaef-d48da1058d5b)
![CleanShot 2024-04-15 at 23 36 21@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/b9035bc9-2450-4c3d-8345-4804991600aa)

