### PR TITLE
Add support for system test cases

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -46,17 +46,23 @@ function NeotestAdapter.discover_positions(file_path)
       (superclass (scope_resolution) @superclass (#match? @superclass "^Minitest::Test"))
     )) @namespace.definition
 
+    ; System tests that inherit from ApplicationSystemTestCase
+    ((
+        class 
+        name: (constant) @namespace.name (superclass) @superclass (#match? @superclass "(ApplicationSystemTestCase)$" )
+    )) @namespace.definition
+
     ; Methods that begin with test_
     ((
       method
       name: (identifier) @test.name (#match? @test.name "^test_")
     )) @test.definition
 
-    ; rails unit test classes
+    ; rails unit classes
     ((
         class
         name: (constant) @namespace.name
-        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase)$"))
+        (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
     )) @namespace.definition
 
     ((
@@ -64,7 +70,6 @@ function NeotestAdapter.discover_positions(file_path)
       method: (identifier) @func_name (#match? @func_name "^(test)$")
       arguments: (argument_list (string (string_content) @test.name))
     )) @test.definition
-
   ]]
 
   return lib.treesitter.parse_positions(file_path, query, {

--- a/tests/adapter/rails_system_spec.lua
+++ b/tests/adapter/rails_system_spec.lua
@@ -1,0 +1,75 @@
+local plugin = require("neotest-minitest")
+local async = require("nio.tests")
+
+describe("Rails System Test", function()
+  assert:set_parameter("TableFormatLevel", -1)
+  describe("discover_positions SystemTestCase", function()
+    async.it("should discover the position for the tests", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/system_test_case.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "system_test_case.rb",
+          path = test_path,
+          range = { 0, 0, 6, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/system_test_case.rb::3",
+            name = "RailsSystemTest",
+            path = test_path,
+            range = { 2, 0, 5, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/system_test_case.rb::4",
+              name = "should pass",
+              path = test_path,
+              range = { 3, 2, 4, 5 },
+              type = "test",
+            },
+          },
+        },
+      }
+      assert.are.same(positions, expected_positions)
+    end)
+  end)
+
+  describe("discover_positions ApplicationSystemTestCase", function()
+    async.it("should discover the position for the tests", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/rails_system_test.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "rails_system_test.rb",
+          path = test_path,
+          range = { 0, 0, 6, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/rails_system_test.rb::3",
+            name = "RailsSystemTest",
+            path = test_path,
+            range = { 2, 0, 5, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/rails_system_test.rb::4",
+              name = "should pass",
+              path = test_path,
+              range = { 3, 2, 4, 5 },
+              type = "test",
+            },
+          },
+        },
+      }
+      assert.are.same(positions, expected_positions)
+    end)
+  end)
+end)

--- a/tests/minitest_examples/application_system_test_case.rb
+++ b/tests/minitest_examples/application_system_test_case.rb
@@ -1,0 +1,15 @@
+require 'minitest/autorun'
+require 'active_support/message_encryptor'
+require 'active_support/dependencies/autoload'
+require 'active_support/test_case'
+require 'action_controller/template_assertions'
+require 'action_dispatch/http/mime_type'
+require 'action_dispatch/testing/assertions'
+require 'action_dispatch/testing/test_process'
+require 'action_dispatch/testing/request_encoder'
+require 'action_dispatch/routing'
+require 'action_dispatch/system_test_case'
+
+class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
+end
+

--- a/tests/minitest_examples/rails_system_test.rb
+++ b/tests/minitest_examples/rails_system_test.rb
@@ -1,0 +1,6 @@
+require_relative "../application_system_test_case"
+
+class RailsSystemTest < ApplicationSystemTestCase
+  test "should pass" do
+  end
+end

--- a/tests/minitest_examples/system_test_case.rb
+++ b/tests/minitest_examples/system_test_case.rb
@@ -1,0 +1,6 @@
+require_relative "../application_system_test_case"
+
+class RailsSystemTest < ActionDispatch::SystemTestCase
+  test "should pass" do
+  end
+end


### PR DESCRIPTION
Based on top of https://github.com/zidhuss/neotest-minitest/pull/12, adds support for system test cases that subclass `ApplicationSystemTestCase` (the rails default) or directly subclass `ActionDispatch::SystemTestCase`.

Before
![CleanShot 2024-04-16 at 11 28 22@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/0718da37-d4f0-4270-b4c0-8125c5f29c76)


After
![CleanShot 2024-04-16 at 11 18 29@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/64d4085c-16b6-47e8-8037-c085252d837a)
![CleanShot 2024-04-16 at 11 18 45@2x](https://github.com/zidhuss/neotest-minitest/assets/1626003/2582de22-41cb-4f7f-96a1-1c99fef739c8)
