### PR TITLE
Fix running tests by directory

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -108,14 +108,33 @@ function NeotestAdapter.build_spec(args)
   end
 
   local function run_dir()
-    table.insert(script_args, position.path .. "/**/*_test.rb")
+    local tree = args.tree
+    local root = tree:root():data().path
+
+    -- This emulates an combination of Rake::TestTask with loader=:direct and
+    -- rake_test_loader
+    table.insert(script_args, "-e")
+    table.insert(script_args, "while (f = ARGV.shift) != '--'; require f; end")
+
+    -- Instruct Ruby to stop parsing options
+    table.insert(script_args, "--")
+
+    for _, node in tree:iter_nodes() do
+      if node:data().type == "file" then
+        local path = node:data().path
+	table.insert(script_args, path)
+      end
+    end
+
+    -- Mark the end of test files
+    table.insert(script_args, "--")
   end
 
   if position.type == "file" then run_by_filename() end
 
   if position.type == "test" or position.type == "namespace" then run_by_name() end
 
-  if position.type == "dir" then return run_dir() end
+  if position.type == "dir" then run_dir() end
 
   local command = vim.tbl_flatten({
     config.get_test_cmd(),


### PR DESCRIPTION
Fixes #21

Previously the code here didn't work, we returned early but with the wrong format. The calling code in neotest interpreted this as "unsupported" and so would itself run tests for every file it knows of.

This implements running multiple files very similar to how Rake::TestTask does, passing the files via ARGV and adding a `-e` script to `require` each file passed.

With this we run all test files in the directory in a single process rather than booting once for each file.