### PR TITLE
Match on exact test name

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -104,7 +104,7 @@ function NeotestAdapter.build_spec(args)
     table.insert(script_args, position.path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
-    table.insert(script_args, "/" .. full_name .. "/")
+    table.insert(script_args, "/^" .. full_name .. "$/")
   end
 
   local function run_dir()


### PR DESCRIPTION
This adds `^` and `$` around the test name so that if we have tests like

```
WhateverTest#test_foo
WhateverTest#test_foobar
```

We are able to run `test_foo` without also running `test_foobar`