### PR TITLE
Match files both named test_*.rb and *_test.rb

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -20,7 +20,7 @@ NeotestAdapter.root = lib.files.match_root_pattern("Gemfile", ".gitignore")
 ---@param file_path string
 ---@return boolean
 function NeotestAdapter.is_test_file(file_path)
-  return vim.endswith(file_path, "_test.rb")
+  return vim.endswith(file_path, "_test.rb") or string.match(file_path, "/test_.+%.rb$") ~= nil
 end
 
 ---Filter directories when searching for test files

--- a/tests/adapter/plugin_spec.lua
+++ b/tests/adapter/plugin_spec.lua
@@ -1,8 +1,12 @@
 local plugin = require("neotest-minitest")
 
 describe("is_test_file", function()
-  it("matches test files", function()
+  it("matches Rails-style test file", function()
     assert.equals(true, plugin.is_test_file("./test/foo_test.rb"))
+  end)
+
+  it("matches minitest-style test file", function()
+    assert.equals(true, plugin.is_test_file("./test/test_foo.rb"))
   end)
 
   it("does not match plain ruby files", function()


### PR DESCRIPTION
It's common both to have test files named `whatever_test.rb` or `test_whatever.rb`. The former is most common in Rails applications, whereas the latter is more common in gems.