### PR TITLE
Add DAP Strategy

### DIFF
--- a/tests/adapter/classic_spec.lua
+++ b/tests/adapter/classic_spec.lua
@@ -2,6 +2,46 @@ local plugin = require("neotest-minitest")
 local async = require("nio.tests")
 
 describe("Classic Test", function()
+  describe("build_spec", function()
+    async.it("should build a spec", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/classic_test.rb"
+      local tree = plugin.discover_positions(test_path)
+
+      local spec = plugin.build_spec({
+        tree = tree,
+        strategy = "dap",
+      })
+
+      local expected_strategy = {
+        args = {
+          "-O",
+          "--port",
+          62164,
+          "-c",
+          "-e",
+          "cont",
+          "--",
+          "bundle",
+          "exec",
+          "ruby",
+          "-Itest",
+          vim.loop.cwd() .. "/tests/minitest_examples/classic_test.rb",
+          "-v",
+        },
+        bundle = "bundle",
+        command = "rdbg",
+        cwd = "${workspaceFolder}",
+        localfs = true,
+        name = "Neotest Debugger",
+        port = 62164,
+        request = "attach",
+        type = "ruby",
+      }
+
+      assert.are.same(spec.strategy, expected_strategy)
+    end)
+  end)
+
   describe("discovers_positions", function()
     async.it("should discover the position of the test", function()
       local test_path = vim.loop.cwd() .. "/tests/minitest_examples/classic_test.rb"


### PR DESCRIPTION
This adds a `dap` strategy to the runner, letting you "debug test" from Neotest.

The ruby-dap adapter doesn't support directly debugging a sub-process - so we have to start the tests in a subprocess and run that subprocess "under" the debugger - then use DAP to connect to the debug server that neotest just started for us.