### PR TITLE
Add Docker Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,42 @@ require("neotest-minitest")({
 })
 ```
 
+### Running tests in a Docker container
+
+The following configuration overrides `test_cmd` to run a Docker container (using `docker-compose`) and overrides `transform_spec_path` to pass the spec file as a relative path instead of an absolute path to Minitest. The `results_path` needs to be set to a location which is available to both the container and the host.
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-minitest")({
+      test_cmd = function()
+        return vim.tbl_flatten({
+          "docker",
+          "compose",
+          "exec",
+          "-i",
+          "-w", "/app",
+          "-e", "RAILS_ENV=test",
+          "app",
+          "bundle",
+          "exec",
+          "test"
+        })
+      end,
+
+      transform_spec_path = function(path)
+        local prefix = require('neotest-minitest').root(path)
+        return string.sub(path, string.len(prefix) + 2, -1)
+      end,
+
+      results_path = "tmp/minitest.output"
+    })
+  }
+})
+```
+
+Alternatively, you can accomplish this using a shell script as your Minitest command. See [this comment](https://github.com/nvim-neotest/neotest/issues/89#issuecomment-1338141432) for an example.
+
 ## :rocket: Usage
 
 _NOTE_: All usages of `require('neotest').run.run` can be mapped to a command in your config (this is not included and should be done by yourself).

--- a/lua/neotest-minitest/config.lua
+++ b/lua/neotest-minitest/config.lua
@@ -9,4 +9,12 @@ M.get_test_cmd = function()
   })
 end
 
+M.transform_spec_path = function(path)
+  return path
+end
+
+M.results_path = function()
+  return require("neotest.async").fn.tempname()
+end
+
 return M

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -91,17 +91,18 @@ end
 function NeotestAdapter.build_spec(args)
   local script_args = {}
   local position = args.tree:data()
-  local results_path = async.fn.tempname()
+  local results_path = config.results_path()
+  local spec_path = config.transform_spec_path(position.path)
 
   local name_mappings = utils.get_mappings(args.tree)
 
   local function run_by_filename()
-    table.insert(script_args, position.path)
+    table.insert(script_args, spec_path)
   end
 
   local function run_by_name()
     local full_name = utils.escaped_full_test_name(args.tree, position.name)
-    table.insert(script_args, position.path)
+    table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
     table.insert(script_args, "/^" .. full_name .. "$/")
@@ -247,6 +248,20 @@ setmetatable(NeotestAdapter, {
     elseif opts.test_cmd then
       config.get_test_cmd = function()
         return opts.test_cmd
+      end
+    end
+    if is_callable(opts.transform_spec_path) then
+      config.transform_spec_path = opts.transform_spec_path
+    elseif opts.transform_spec_path then
+      config.transform_spec_path = function()
+        return opts.transform_spec_path
+      end
+    end
+    if is_callable(opts.results_path) then
+      config.results_path = opts.results_path
+    elseif opts.results_path then
+      config.results_path = function()
+        return opts.results_path
       end
     end
     return NeotestAdapter


### PR DESCRIPTION
Closes #11

This PR adds support for running minitest in a docker container through a couple of new config options:
- `transform_spec_path` allows the spec path to be modified before being passed to minitest. When running in a docker container a relative path needs to be used instead of an absolute path.
- `results_path` allows the results file to be modified so that it's available to both the docker container and host.

Thanks to @ramblex for the [neotest-rspec PR](https://github.com/olimorris/neotest-rspec/pull/52) which this PR basically copies.
