### PR TITLE
feat: initial support minitest spec dsl (describe|context|it)

### DIFF
--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -128,7 +128,7 @@ function NeotestAdapter.build_spec(args)
   end
 
   local function run_by_name()
-    local full_spec_name = utils.escaped_full_spec_name(args.tree)
+    local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -72,12 +72,14 @@ function NeotestAdapter.discover_positions(file_path)
         (superclass (scope_resolution) @superclass (#match? @superclass "(::IntegrationTest|::TestCase|::SystemTestCase)$"))
     )) @namespace.definition
 
-    ((call
+    ((
+      call
       method: (identifier) @func_name (#match? @func_name "^(describe|context)$")
-      arguments: (argument_list (_) @namespace.name)
+      arguments: (argument_list (string (string_content) @namespace.name))
     )) @namespace.definition
 
-    ((call
+    ((
+      call
       method: (identifier) @namespace.name (#match? @namespace.name "^(describe|context)$")
       .
       block: (_)
@@ -89,20 +91,10 @@ function NeotestAdapter.discover_positions(file_path)
       arguments: (argument_list (string (string_content) @test.name))
     )) @test.definition
 
-    ((call
+    ((
+      call
       method: (identifier) @func_name (#match? @func_name "^(it)$")
-      block: (block (_) @test.name)
-    )) @test.definition
-
-    ((call
-      method: (identifier) @func_name (#match? @func_name "^(it)$")
-      block: (do_block (_) @test.name)
-      !arguments
-    )) @test.definition
-
-    ((call
-      method: (identifier) @func_name (#match? @func_name "^(it)$")
-      arguments: (argument_list (_) @test.name)
+      arguments: (argument_list (string (string_content) @test.name))
     )) @test.definition
   ]]
 
@@ -132,7 +124,7 @@ function NeotestAdapter.build_spec(args)
     local full_test_name = utils.escaped_full_test_name(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
-    -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-rawt st/
+    -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
     table.insert(script_args, "/^" .. full_spec_name .. "|" .. full_test_name .. "$/")
   end
 

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -40,21 +40,15 @@ M.generate_treesitter_id = function(position, parents)
   return id
 end
 
----@param s string
-local function unquote(s)
-  local r, _ = s:gsub("^['\"]*([^'\"]*)['\"]*$", "%1")
-  return r
-end
-
 M.full_spec_name = function(tree)
-  local name = unquote(tree:data().name)
+  local name = tree:data().name
   local namespaces = {}
   local num_namespaces = 0
 
   for parent_node in tree:iter_parents() do
     local data = parent_node:data()
     if data.type == "namespace" then
-      table.insert(namespaces, 1, unquote(parent_node:data().name))
+      table.insert(namespaces, 1, parent_node:data().name)
       num_namespaces = num_namespaces + 1
     else
       break

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -41,9 +41,16 @@ M.generate_treesitter_id = function(position, parents)
 end
 
 M.full_spec_name = function(tree)
-  local name = tree:data().name
+  local name = ""
   local namespaces = {}
   local num_namespaces = 0
+
+  if tree:data().type == "namespace" then
+    table.insert(namespaces, 1, tree:data().name)
+    num_namespaces = num_namespaces + 1
+  else
+    name = tree:data().name
+  end
 
   for parent_node in tree:iter_parents() do
     local data = parent_node:data()
@@ -59,8 +66,12 @@ M.full_spec_name = function(tree)
 
   -- build result
   local result = ""
+
   -- assemble namespaces
   result = table.concat(namespaces, "::")
+
+  if name == "" then return result end
+
   -- add # separator
   result = result .. "#"
   -- add test_ prefix

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -42,7 +42,7 @@ end
 
 ---@param s string
 local function unquote(s)
-  local r, _ = s:gsub("^[']*([^']*)[']*$", "%1")
+  local r, _ = s:gsub("^['\"]*([^'\"]*)['\"]*$", "%1")
   return r
 end
 
@@ -93,11 +93,6 @@ M.full_test_name = function(tree)
   if not name:match("^test_") then name = "test_" .. name end
 
   return parent_name .. "#" .. name:gsub(" ", "_")
-end
-
-M.escaped_full_spec_name = function(tree)
-  local full_name = M.full_spec_name(tree)
-  return full_name:gsub("([?#])", "\\%1")
 end
 
 M.escaped_full_test_name = function(tree)

--- a/tests/adapter/rails_unit_spec.lua
+++ b/tests/adapter/rails_unit_spec.lua
@@ -4,7 +4,7 @@ local async = require("nio.tests")
 describe("Rails Unit Test", function()
   assert:set_parameter("TableFormatLevel", -1)
   describe("discover_positions", function()
-    async.it("should discover the position fo the tests", function()
+    async.it("should discover the position for the tests", function()
       local test_path = vim.loop.cwd() .. "/tests/minitest_examples/rails_unit_test.rb"
       local positions = plugin.discover_positions(test_path):to_list()
       local expected_positions = {

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -64,6 +64,67 @@ describe("Spec Test", function()
 
       assert.are.same(positions, expected_positions)
     end)
+
+    async.it("should discover the position for the tests, minispec-test-rails variant", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/rails_spec_test.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "rails_spec_test.rb",
+          path = test_path,
+          range = { 0, 0, 18, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/rails_spec_test.rb::6",
+            name = "RailsSpecTest",
+            path = test_path,
+            range = { 5, 0, 17, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/rails_spec_test.rb::7",
+              name = "addition",
+              path = test_path,
+              range = { 6, 2, 10, 5 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/minitest_examples/rails_spec_test.rb::8",
+                name = "adds two numbers",
+                path = test_path,
+                range = { 7, 4, 9, 7 },
+                type = "test",
+              },
+            },
+          },
+          {
+            {
+              id = "./tests/minitest_examples/rails_spec_test.rb::13",
+              name = "subtraction",
+              path = test_path,
+              range = { 12, 2, 16, 5 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/minitest_examples/rails_spec_test.rb::14",
+                name = "subtracts two numbers",
+                path = test_path,
+                range = { 13, 4, 15, 7 },
+                type = "test",
+              },
+            },
+          },
+        },
+      }
+
+      assert.are.same(positions, expected_positions)
+    end)
   end)
 
   describe("_parse_test_output", function()

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -18,7 +18,7 @@ describe("Spec Test", function()
         {
           {
             id = "./tests/minitest_examples/spec_test.rb::6",
-            name = "'SpecTest'",
+            name = "SpecTest",
             path = test_path,
             range = { 5, 0, 17, 3 },
             type = "namespace",
@@ -26,7 +26,7 @@ describe("Spec Test", function()
           {
             {
               id = "./tests/minitest_examples/spec_test.rb::7",
-              name = "'addition'",
+              name = "addition",
               path = test_path,
               range = { 6, 2, 10, 5 },
               type = "namespace",
@@ -34,7 +34,7 @@ describe("Spec Test", function()
             {
               {
                 id = "./tests/minitest_examples/spec_test.rb::8",
-                name = "'adds two numbers'",
+                name = "adds two numbers",
                 path = test_path,
                 range = { 7, 4, 9, 7 },
                 type = "test",
@@ -44,7 +44,7 @@ describe("Spec Test", function()
           {
             {
               id = "./tests/minitest_examples/spec_test.rb::13",
-              name = "'subtraction'",
+              name = "subtraction",
               path = test_path,
               range = { 12, 2, 16, 5 },
               type = "namespace",
@@ -52,7 +52,7 @@ describe("Spec Test", function()
             {
               {
                 id = "./tests/minitest_examples/spec_test.rb::14",
-                name = "'subtracts two numbers'",
+                name = "subtracts two numbers",
                 path = test_path,
                 range = { 13, 4, 15, 7 },
                 type = "test",

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -12,49 +12,49 @@ describe("Spec Test", function()
           id = test_path,
           name = "spec_test.rb",
           path = test_path,
-          range = { 0, 0, 17, 0 },
+          range = { 0, 0, 18, 0 },
           type = "file",
         },
         {
           {
-            id = "./tests/minitest_examples/spec_test.rb::5",
-            name = "SpecTest",
+            id = "./tests/minitest_examples/spec_test.rb::6",
+            name = "'SpecTest'",
             path = test_path,
-            range = { 4, 0, 16, 3 },
+            range = { 5, 0, 17, 3 },
             type = "namespace",
           },
           {
             {
-              id = "./tests/minitest_examples/spec_test.rb::6",
-              name = "'#add'",
+              id = "./tests/minitest_examples/spec_test.rb::7",
+              name = "'addition'",
               path = test_path,
-              range = { 5, 2, 9, 5 },
+              range = { 6, 2, 10, 5 },
               type = "namespace",
             },
             {
               {
-                id = "./tests/minitest_examples/spec_test.rb::7",
-                name = "adds two numbers",
+                id = "./tests/minitest_examples/spec_test.rb::8",
+                name = "'adds two numbers'",
                 path = test_path,
-                range = { 6, 4, 8, 7 },
+                range = { 7, 4, 9, 7 },
                 type = "test",
               },
             },
           },
           {
             {
-              id = "./tests/minitest_examples/spec_test.rb::12",
-              name = "'#subtract'",
+              id = "./tests/minitest_examples/spec_test.rb::13",
+              name = "'subtraction'",
               path = test_path,
-              range = { 11, 2, 15, 5 },
+              range = { 12, 2, 16, 5 },
               type = "namespace",
             },
             {
               {
-                id = "./tests/minitest_examples/spec_test.rb::13",
-                name = "subtracts two numbers",
+                id = "./tests/minitest_examples/spec_test.rb::14",
+                name = "'subtracts two numbers'",
                 path = test_path,
-                range = { 12, 4, 14, 7 },
+                range = { 13, 4, 15, 7 },
                 type = "test",
               },
             },
@@ -69,18 +69,18 @@ describe("Spec Test", function()
   describe("_parse_test_output", function()
     describe("single failing test", function()
       local output = [[
-SpecTest#test_adds_two_numbers = 0.00 s = F
-
+SpecTest::addition#test_0001_adds two numbers = 0.00 s = F
 
 Failure:
-SpecTest#test_adds_two_numbers [/src/nvim-neotest/neotest-minitest/tests/minitest_examples/spec_test.rb:8]:
+SpecTest::addition#test_0001_adds two numbers [tests/minitest_examples/spec_test.rb:9]:
 Expected: 4
   Actual: 5
 
 
     ]]
       it("parses the results correctly", function()
-        local results = plugin._parse_test_output(output, { ["SpecTest#test_adds_two_numbers"] = "testing" })
+        local results =
+          plugin._parse_test_output(output, { ["SpecTest::addition#test_0001_adds two numbers"] = "testing" })
 
         assert.are.same(
           { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } } },

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -83,7 +83,7 @@ Expected: 4
           plugin._parse_test_output(output, { ["SpecTest::addition#test_0001_adds two numbers"] = "testing" })
 
         assert.are.same(
-          { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } } },
+          { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 8 } } } },
           results
         )
       end)
@@ -142,11 +142,12 @@ tests/minitest_examples/rails_unit_erroring_test.rb:1:in `require': cannot load 
 
     describe("single passing test", function()
       local output = [[
-SpecTest#test_subtracts_two_numbers = 0.00 s = .
+SpecTest::subtraction#test_0001_subtracts two numbers = 0.00 s = .
 ]]
 
       it("parses the results correctly", function()
-        local results = plugin._parse_test_output(output, { ["SpecTest#test_subtracts_two_numbers"] = "testing" })
+        local results =
+          plugin._parse_test_output(output, { ["SpecTest::subtraction#test_0001_subtracts two numbers"] = "testing" })
 
         assert.are.same({ ["testing"] = { status = "passed" } }, results)
       end)

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -1,0 +1,237 @@
+local plugin = require("neotest-minitest")
+local async = require("nio.tests")
+
+describe("Spec Test", function()
+  assert:set_parameter("TableFormatLevel", -1)
+  describe("discover_positions", function()
+    async.it("should discover the position fo the tests", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/spec_test.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "spec_test.rb",
+          path = test_path,
+          range = { 0, 0, 17, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/spec_test.rb::5",
+            name = "SpecTest",
+            path = test_path,
+            range = { 4, 0, 16, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/spec_test.rb::6",
+              name = "'#add'",
+              path = test_path,
+              range = { 5, 2, 9, 5 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/minitest_examples/spec_test.rb::7",
+                name = "adds two numbers",
+                path = test_path,
+                range = { 6, 4, 8, 7 },
+                type = "test",
+              },
+            },
+          },
+          {
+            {
+              id = "./tests/minitest_examples/spec_test.rb::12",
+              name = "'#subtract'",
+              path = test_path,
+              range = { 11, 2, 15, 5 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/minitest_examples/spec_test.rb::13",
+                name = "subtracts two numbers",
+                path = test_path,
+                range = { 12, 4, 14, 7 },
+                type = "test",
+              },
+            },
+          },
+        },
+      }
+
+      assert.are.same(positions, expected_positions)
+    end)
+  end)
+
+  describe("_parse_test_output", function()
+    describe("single failing test", function()
+      local output = [[
+SpecTest#test_adds_two_numbers = 0.00 s = F
+
+
+Failure:
+SpecTest#test_adds_two_numbers [/src/nvim-neotest/neotest-minitest/tests/minitest_examples/spec_test.rb:8]:
+Expected: 4
+  Actual: 5
+
+
+    ]]
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, { ["SpecTest#test_adds_two_numbers"] = "testing" })
+
+        assert.are.same(
+          { ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } } },
+          results
+        )
+      end)
+    end)
+
+    describe("single passing test with ruby error", function()
+      local output = [[
+Traceback (most recent call last):
+        1: from tests/minitest_examples/rails_unit_erroring_test.rb:1:in `<main>'
+tests/minitest_examples/rails_unit_erroring_test.rb:1:in `require': cannot load such file -- non_exising_file (LoadError)
+      ]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, { ["RailsUnitErroringTest#test_addition"] = "testing" })
+
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+        }, results)
+      end)
+    end)
+
+    describe("multiple tests with ruby error", function()
+      local output = [[
+Traceback (most recent call last):
+        1: from tests/minitest_examples/rails_unit_erroring_test.rb:1:in `<main>'
+tests/minitest_examples/rails_unit_erroring_test.rb:1:in `require': cannot load such file -- non_exising_file (LoadError)
+      ]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, {
+          ["RailsUnitErroringTest#test_addition"] = "testing",
+          ["SpecTest#test_subtracts_two_numbers"] = "testing1",
+        })
+
+        assert.are.same({
+          ["testing"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+          ["testing1"] = {
+            status = "failed",
+            errors = {
+              { message = "in `require': cannot load such file -- non_exising_file (LoadError)", line = 0 },
+            },
+          },
+        }, results)
+      end)
+    end)
+
+    describe("single passing test", function()
+      local output = [[
+SpecTest#test_subtracts_two_numbers = 0.00 s = .
+]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, { ["SpecTest#test_subtracts_two_numbers"] = "testing" })
+
+        assert.are.same({ ["testing"] = { status = "passed" } }, results)
+      end)
+    end)
+
+    describe("failing and passing tests", function()
+      local output = [[
+SpecTest#test_subtracts_two_numbers = 0.00 s = .
+SpecTest#test_adds_two_numbers = 0.00 s = F
+
+
+Failure:
+SpecTest#test_adds_two_numbers [/neotest-minitest/tests/minitest_examples/spec_test.rb:8]:
+Expected: 4
+  Actual: 5
+
+
+    ]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, {
+          ["SpecTest#test_adds_two_numbers"] = "testing",
+          ["SpecTest#test_subtracts_two_numbers"] = "testing2",
+        })
+
+        assert.are.same({
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } },
+          ["testing2"] = { status = "passed" },
+        }, results)
+      end)
+    end)
+
+    describe("multiple failing tests", function()
+      local output = [[
+SpecTest#test_adds_two_numbers = 0.00 s = F
+
+
+Failure:
+SpecTest#test_adds_two_numbers [/neotest-minitest/tests/minitest_examples/spec_test.rb:8]:
+Expected: 4
+  Actual: 5
+
+
+rails test Users/abry/src/nvim-neotest/neotest-minitest/tests/minitest_examples/spec_test.rb:7
+
+SpecTest#test_subtracts_two_numbers = 0.00 s = F
+
+
+Failure:
+SpecTest#test_subtracts_two_numbers [/neotest-minitest/tests/minitest_examples/spec_test.rb:11]:
+Expected: 1
+  Actual: 2
+
+
+  ]]
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, {
+          ["SpecTest#test_adds_two_numbers"] = "testing",
+          ["SpecTest#test_subtracts_two_numbers"] = "testing2",
+        })
+
+        assert.are.same({
+          ["testing"] = { status = "failed", errors = { { message = "Expected: 4\n  Actual: 5", line = 7 } } },
+          ["testing2"] = { status = "failed", errors = { { message = "Expected: 1\n  Actual: 2", line = 10 } } },
+        }, results)
+      end)
+    end)
+
+    describe("multiple passing tests", function()
+      local output = [[
+SpecTest#test_subtracts_two_numbers = 0.00 s = .
+SpecTest#test_adds_two_numbers = 0.00 s = .
+    ]]
+
+      it("parses the results correctly", function()
+        local results = plugin._parse_test_output(output, {
+          ["SpecTest#test_adds_two_numbers"] = "testing",
+          ["SpecTest#test_subtracts_two_numbers"] = "testing2",
+        })
+
+        assert.are.same({
+          ["testing"] = { status = "passed" },
+          ["testing2"] = { status = "passed" },
+        }, results)
+      end)
+    end)
+  end)
+end)

--- a/tests/adapter/spec_spec.lua
+++ b/tests/adapter/spec_spec.lua
@@ -4,7 +4,7 @@ local async = require("nio.tests")
 describe("Spec Test", function()
   assert:set_parameter("TableFormatLevel", -1)
   describe("discover_positions", function()
-    async.it("should discover the position fo the tests", function()
+    async.it("should discover the position for the tests", function()
       local test_path = vim.loop.cwd() .. "/tests/minitest_examples/spec_test.rb"
       local positions = plugin.discover_positions(test_path):to_list()
       local expected_positions = {

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -35,6 +35,8 @@ describe("full_spec_name", function()
     }, function(pos)
       return pos.id
     end)
+
+    assert.equals("namespace1::namespace2::namespace3", utils.full_spec_name(tree:children()[1]:children()[1]))
     assert.equals(
       "namespace1::namespace2::namespace3#test_0001_example",
       utils.full_spec_name(tree:children()[1]:children()[1]:children()[1])

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -19,6 +19,77 @@ describe("generate_treesitter_id", function()
   end)
 end)
 
+describe("full_spec_name", function()
+  it("concatenates namespaces with :: separator", function()
+    local tree = Tree.from_list({
+      { id = "namespace1", name = "namespace1", type = "namespace" },
+      {
+        { id = "namespace2", name = "namespace2", type = "namespace" },
+        {
+          { id = "namespace3", name = "namespace3", type = "namespace" },
+          {
+            { id = "test", name = "example" },
+          },
+        },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals(
+      "namespace1::namespace2::namespace3#test_0001_example",
+      utils.full_spec_name(tree:children()[1]:children()[1]:children()[1])
+    )
+  end)
+
+  it("includes a zero-padded test index", function()
+    local tree = Tree.from_list({
+      { id = "namespace1", name = "namespace1", type = "namespace" },
+      {
+        { id = "namespace2", name = "namespace2", type = "namespace" },
+        {
+          { id = "namespace3", name = "namespace3", type = "namespace" },
+          {
+            { id = "test1", name = "example1" },
+          },
+          {
+            { id = "test2", name = "example2" },
+          },
+          {
+            { id = "test3", name = "example3" },
+          },
+        },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals(
+      "namespace1::namespace2::namespace3#test_0002_example2",
+      utils.full_spec_name(tree:children()[1]:children()[1]:children()[2])
+    )
+  end)
+
+  it("does not replace spaces with underscores", function()
+    local tree = Tree.from_list({
+      { id = "namespace1", name = "namespace1", type = "namespace" },
+      {
+        { id = "namespace2", name = "namespace2", type = "namespace" },
+        {
+          { id = "namespace3", name = "namespace3", type = "namespace" },
+          {
+            { id = "test", name = "this is a great test name" },
+          },
+        },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+    assert.equals(
+      "namespace1::namespace2::namespace3#test_0001_this is a great test name",
+      utils.full_spec_name(tree:children()[1]:children()[1]:children()[1])
+    )
+  end)
+end)
+
 describe("full_test_name", function()
   it("returns the name of the test", function()
     local tree = Tree.from_list({ id = "test", name = "test_example" }, function(pos)

--- a/tests/minitest_examples/rails_spec_test.rb
+++ b/tests/minitest_examples/rails_spec_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# RailsSpecTest captures what it looks like to write a Rails TestCase using
+# minitest DSL. One way to enable this in a Rails project is by using:
+# https://github.com/metaskills/minitest-spec-rails
+class RailsSpecTest < ActiveSupport::TestCase
+  context 'addition' do
+    test 'adds two numbers' do
+      assert_equal 2 + 2, 5
+    end
+  end
+
+  context 'subtraction' do
+    test 'subtracts two numbers' do
+      assert_equal 3 - 2, 1
+    end
+  end
+end

--- a/tests/minitest_examples/spec_test.rb
+++ b/tests/minitest_examples/spec_test.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
+require 'minitest/spec'
 require 'minitest/autorun'
 
-class SpecTest < Minitest::Spec
-  describe '#add' do
-    test 'adds two numbers' do
-      assert_equal 2 + 2, 4
+describe 'SpecTest' do
+  describe 'addition' do
+    it 'adds two numbers' do
+      assert_equal 2 + 2, 5
     end
   end
 
-  describe '#subtract' do
-    test 'subtracts two numbers' do
+  describe 'subtraction' do
+    it 'subtracts two numbers' do
       assert_equal 3 - 2, 1
     end
   end

--- a/tests/minitest_examples/spec_test.rb
+++ b/tests/minitest_examples/spec_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+
+class SpecTest < Minitest::Spec
+  describe '#add' do
+    test 'adds two numbers' do
+      assert_equal 2 + 2, 4
+    end
+  end
+
+  describe '#subtract' do
+    test 'subtracts two numbers' do
+      assert_equal 3 - 2, 1
+    end
+  end
+end


### PR DESCRIPTION
Addresses #30.

Add initial, limited support for `Minitest::Spec`-style tests. This PR just adds support for `describe`, `context`, and `it` calls.