### PR TITLE
Neotest extended DSL support: Should and Shoulda-matchers + Streaming

### DIFF
--- a/lua/neotest-minitest/config.lua
+++ b/lua/neotest-minitest/config.lua
@@ -1,12 +1,7 @@
 local M = {}
 
 M.get_test_cmd = function()
-  return vim.tbl_flatten({
-    "bundle",
-    "exec",
-    "ruby",
-    "-Itest",
-  })
+  return { "bundle", "exec", "ruby", "-Itest" }
 end
 
 M.transform_spec_path = function(path)

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -171,6 +171,7 @@ function NeotestAdapter.build_spec(args)
       local full_spec_name = utils.full_spec_name(args.tree)
       local full_test_name = utils.escaped_full_test_name(args.tree)
       local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
+      local permissive = utils.permissive_should_pattern(args.tree)
       -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
       -- Shoulda-context method symbols end with a literal space (e.g. :"test_: X should
       -- Y. "). Minitest compares the filter regex against "#{klass}##{method}", so the
@@ -181,7 +182,16 @@ function NeotestAdapter.build_spec(args)
         .. full_test_name
         .. "|"
         .. full_shoulda_test_name
-        .. " $/"
+        .. " $"
+      -- Permissive `<Class>.*should <name>` covers the class-level string-form case in
+      -- module-scoped classes (shoulda emits the module-prefixed class name in the
+      -- description, which the literal full_shoulda_test_name above can't tolerate).
+      -- Harmless for `test "X"`/`it "X"` positions — the runtime method name has no
+      -- `should` token so the regex doesn't match anything spurious.
+      if permissive then
+        pattern = pattern .. "|" .. (permissive:gsub("([?])", "\\%1"))
+      end
+      pattern = pattern .. "/"
     end
     table.insert(script_args, pattern)
   end

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -102,6 +102,23 @@ function NeotestAdapter.discover_positions(file_path)
       method: (identifier) @func_name (#match? @func_name "^(should)$")
       arguments: (argument_list (string (string_content) @test.name))
     )) @test.definition
+
+    ; shoulda-matchers form: `should belong_to(:cycle)`, `should have_many(...)`, etc.
+    ; Matched by accepting a method-call (or chained calls) instead of a string literal.
+    ((
+      call
+      method: (identifier) @func_name (#match? @func_name "^(should)$")
+      arguments: (argument_list (call) @test.name)
+    )) @test.definition
+
+    ; Project-specific class-method test helpers, e.g. `it_requires_authentication { ... }`.
+    ; The identifier itself is captured as the test name; downstream code derives the
+    ; runtime description (e.g. "require authentication") from the suffix.
+    ((
+      call
+      method: (identifier) @test.name (#match? @test.name "^it_requires_[a-z_]+$")
+      block: (_)
+    )) @test.definition
   ]]
 
   return lib.treesitter.parse_positions(file_path, query, {
@@ -119,7 +136,7 @@ function NeotestAdapter.build_spec(args)
   local results_path = config.results_path()
   local spec_path = config.transform_spec_path(position.path)
 
-  local name_mappings = utils.get_mappings(args.tree)
+  local name_mappings, prefix_mappings = utils.get_mappings(args.tree)
 
   local function run_by_filename()
     table.insert(script_args, spec_path)
@@ -129,16 +146,28 @@ function NeotestAdapter.build_spec(args)
     local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
     local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
+    local prefix = utils.full_shoulda_prefix(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
     -- Shoulda-context method symbols end with a literal space (e.g. :"test_: X should Y. ").
     -- Minitest compares the filter regex against "#{klass}##{method}", so the suffix
     -- alternative must end with that trailing space.
-    table.insert(
-      script_args,
-      "/^" .. full_spec_name .. "|" .. full_test_name .. "|" .. full_shoulda_test_name .. " $/"
-    )
+    local pattern = "/^"
+      .. full_spec_name
+      .. "|"
+      .. full_test_name
+      .. "|"
+      .. full_shoulda_test_name
+      .. " $"
+    -- For shoulda-matchers (`should belong_to(:cycle)`) and `it_requires_*` helpers,
+    -- the runtime test name carries a suffix we can't predict from source (matcher
+    -- options or random hex). Append the prefix as an additional alternative — minitest
+    -- uses regex matching for --name, so the prefix matches any test whose name starts
+    -- with it. Over-matches sibling matchers in the same context, which is acceptable.
+    if prefix then pattern = pattern .. "|" .. prefix:gsub("([?])", "\\%1") end
+    pattern = pattern .. "/"
+    table.insert(script_args, pattern)
   end
 
   -- When true, replaces config.get_test_cmd() with `bundle exec bin/rails test` for
@@ -235,7 +264,7 @@ function NeotestAdapter.build_spec(args)
     "-v",
   }):flatten():totable()
 
-  local stream = NeotestAdapter._make_status_stream(name_mappings)
+  local stream = NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
 
   if args.strategy == "dap" then
     return {
@@ -244,6 +273,7 @@ function NeotestAdapter.build_spec(args)
         results_path = results_path,
         pos_id = position.id,
         name_mappings = name_mappings,
+        prefix_mappings = prefix_mappings,
       },
       strategy = dap_strategy(command),
       stream = stream,
@@ -256,6 +286,7 @@ function NeotestAdapter.build_spec(args)
         results_path = results_path,
         pos_id = position.id,
         name_mappings = name_mappings,
+        prefix_mappings = prefix_mappings,
       },
       stream = stream,
     }
@@ -333,7 +364,28 @@ local iter_test_output_status = function(output)
   end
 end
 
-function NeotestAdapter._parse_test_output(output, name_mappings)
+-- Tries an exact lookup in name_mappings first (after stripping module prefixes if
+-- needed). Falls back to scanning prefix_mappings for any prefix that is a literal
+-- prefix of the test_name. Returns the matching pos_id or nil.
+local function lookup_pos_id(test_name, name_mappings, prefix_mappings)
+  local pos_id = name_mappings[test_name]
+  if pos_id then return pos_id end
+
+  local stripped = utils.replace_module_namespace(test_name)
+  if name_mappings[stripped] then return name_mappings[stripped] end
+
+  if prefix_mappings then
+    for prefix, prefix_pos_id in pairs(prefix_mappings) do
+      if test_name:sub(1, #prefix) == prefix or stripped:sub(1, #prefix) == prefix then
+        return prefix_pos_id
+      end
+    end
+  end
+
+  return nil
+end
+
+function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mappings)
   local results = {}
   local error_pattern = "Error:%s*([%w:#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
   local traceback_pattern = "(%d+:[^:]+:%d+:in `[^']+')%s+([^:]+):(%d+):(in `[^']+':[^\n]+)"
@@ -354,11 +406,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
   end
 
   for test_name, status in iter_test_output_status(output) do
-    local pos_id = name_mappings[test_name]
-    if not pos_id then
-      test_name = utils.replace_module_namespace(test_name)
-      if name_mappings[test_name] then pos_id = name_mappings[test_name] end
-    end
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
 
     if pos_id then results[pos_id] = {
       status = status == "." and "passed" or "failed",
@@ -368,11 +416,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
   for test_name, filepath, expected, actual in iter_test_output_error(output) do
     local message = string.format("Expected: %s\n  Actual: %s", expected, actual)
 
-    local pos_id = name_mappings[test_name]
-    if not pos_id then
-      test_name = utils.replace_module_namespace(test_name)
-      pos_id = name_mappings[test_name]
-    end
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
 
     local line = tonumber(string.match(filepath, ":(%d+)$"))
     if results[pos_id] then
@@ -387,10 +431,9 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
   end
 
   for test_name, message, line_str in string.gmatch(output, error_pattern) do
-    test_name = utils.replace_module_namespace(test_name)
     local line = tonumber(line_str)
-    local pos_id = name_mappings[test_name]
-    if results[pos_id] then
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
+    if pos_id and results[pos_id] then
       results[pos_id].status = "failed"
       results[pos_id].errors = {
         {
@@ -412,7 +455,7 @@ end
 -- Per-test errors and tracebacks are intentionally not surfaced here — they're
 -- multi-line and require the full output to parse safely. NeotestAdapter.results
 -- runs on the captured output file at process exit and fills those in.
-function NeotestAdapter._make_status_stream(name_mappings)
+function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
   return function(output_stream)
     local buffer = ""
 
@@ -439,11 +482,7 @@ function NeotestAdapter._make_status_stream(name_mappings)
         local r_start, _, status = line:find(status_line_pattern)
         if r_start and status then
           local test_name = line:sub(1, r_start - 1)
-          local pos_id = name_mappings[test_name]
-          if not pos_id then
-            test_name = utils.replace_module_namespace(test_name)
-            pos_id = name_mappings[test_name]
-          end
+          local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
           if pos_id then
             results[pos_id] = {
               status = status == "." and "passed" or "failed",
@@ -470,7 +509,11 @@ function NeotestAdapter.results(spec, result, tree)
   end
 
   output = utils.strip_ansi_escape_codes(output)
-  local results = NeotestAdapter._parse_test_output(output, spec.context.name_mappings)
+  local results = NeotestAdapter._parse_test_output(
+    output,
+    spec.context.name_mappings,
+    spec.context.prefix_mappings
+  )
 
   return results
 end

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -104,10 +104,11 @@ function NeotestAdapter.discover_positions(file_path)
     )) @test.definition
 
     ; shoulda-matchers form: `should belong_to(:cycle)`, `should have_many(...)`, etc.
-    ; Matched by accepting a method-call (or chained calls) instead of a string literal.
+    ; The matched method name (`should` vs `should_not`) is preserved as @func_name so
+    ; the custom build_position callback can mark negated forms with a `not ` prefix.
     ((
       call
-      method: (identifier) @func_name (#match? @func_name "^(should)$")
+      method: (identifier) @func_name (#match? @func_name "^(should|should_not)$")
       arguments: (argument_list (call) @test.name)
     )) @test.definition
 
@@ -125,6 +126,7 @@ function NeotestAdapter.discover_positions(file_path)
     nested_tests = true,
     require_namespaces = true,
     position_id = "require('neotest-minitest.utils').generate_treesitter_id",
+    build_position = "require('neotest-minitest.utils').build_position",
   })
 end
 

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -128,7 +128,7 @@ function NeotestAdapter.build_spec(args)
   local function run_by_name()
     local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
-    local full_shoulda_test_name = utils.full_shoulda_test_name(args.tree):gsub("([?])", "\\%1")
+    local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -128,10 +128,17 @@ function NeotestAdapter.build_spec(args)
   local function run_by_name()
     local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
+    local full_shoulda_test_name = utils.full_shoulda_test_name(args.tree):gsub("([?])", "\\%1")
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
-    table.insert(script_args, "/^" .. full_spec_name .. "|" .. full_test_name .. "$/")
+    -- Shoulda-context method symbols end with a literal space (e.g. :"test_: X should Y. ").
+    -- Minitest compares the filter regex against "#{klass}##{method}", so the suffix
+    -- alternative must end with that trailing space.
+    table.insert(
+      script_args,
+      "/^" .. full_spec_name .. "|" .. full_test_name .. "|" .. full_shoulda_test_name .. " $/"
+    )
   end
 
   local function run_dir()

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -146,7 +146,7 @@ function NeotestAdapter.build_spec(args)
     local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
     local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
-    local prefixes = utils.full_shoulda_prefixes(args.tree)
+    local run_patterns = utils.full_shoulda_run_patterns(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
@@ -162,13 +162,14 @@ function NeotestAdapter.build_spec(args)
       .. " $"
     -- For shoulda-matchers (`should belong_to(:cycle)`) and `it_requires_*` helpers,
     -- the runtime test name carries a suffix we can't predict from source (matcher
-    -- options or random hex). Append each derived prefix as an additional alternative —
-    -- minitest's --name accepts regex, so the prefix matches any test whose name starts
-    -- with it. Composite helpers like `it_requires_all_auth` yield multiple prefixes so
-    -- running the position runs all of its sub-tests.
-    if prefixes then
-      for _, prefix in ipairs(prefixes) do
-        pattern = pattern .. "|" .. prefix:gsub("([?])", "\\%1")
+    -- options or random hex). Append each derived run pattern (`<Class>.*should <desc>`)
+    -- as an additional regex alternative. The `.*` tolerates module-prefixed class names
+    -- in the description that shoulda-context emits for module-scoped classes. Composite
+    -- helpers like `it_requires_all_auth` yield multiple patterns so running the
+    -- position runs all of its sub-tests.
+    if run_patterns then
+      for _, run_pattern in ipairs(run_patterns) do
+        pattern = pattern .. "|" .. run_pattern:gsub("([?])", "\\%1")
       end
     end
     pattern = pattern .. "/"

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -141,12 +141,33 @@ function NeotestAdapter.build_spec(args)
     )
   end
 
+  -- When true, replaces config.get_test_cmd() with `bundle exec bin/rails test` for
+  -- dir runs. Set inside run_dir() if the project root contains a bin/rails stub.
+  local use_rails_test_runner = false
+
   local function run_dir()
     local tree = args.tree
     local root = tree:root():data().path
+    local rails_bin = root .. "/bin/rails"
 
-    -- This emulates an combination of Rake::TestTask with loader=:direct and
-    -- rake_test_loader
+    if vim.loop.fs_stat(rails_bin) then
+      -- Rails project: defer to `bin/rails test <files>`. This routes through
+      -- Rails' own test runner, which shares Rails boot across files, manages
+      -- fixtures, and supports parallel workers — none of which work cleanly
+      -- under bare `ruby -Itest -e '<require loop>'` once the test tree gets
+      -- past trivial size (the require-storm deadlocks against PTY in pry/
+      -- parallel-executor setup for larger Rails apps).
+      use_rails_test_runner = true
+      for _, node in tree:iter_nodes() do
+        if node:data().type == "file" then
+          table.insert(script_args, node:data().path)
+        end
+      end
+      return
+    end
+
+    -- Non-Rails project: emulate Rake::TestTask with loader=:direct and
+    -- rake_test_loader.
     table.insert(script_args, "-e")
     table.insert(script_args, "while (f = ARGV.shift) != '--'; require f; end")
 
@@ -201,11 +222,20 @@ function NeotestAdapter.build_spec(args)
 
   if position.type == "dir" then run_dir() end
 
+  local cmd_prefix
+  if use_rails_test_runner then
+    cmd_prefix = { "bundle", "exec", "bin/rails", "test" }
+  else
+    cmd_prefix = config.get_test_cmd()
+  end
+
   local command = vim.tbl_flatten({
-    config.get_test_cmd(),
+    cmd_prefix,
     script_args,
     "-v",
   })
+
+  local stream = NeotestAdapter._make_status_stream(name_mappings)
 
   if args.strategy == "dap" then
     return {
@@ -216,6 +246,7 @@ function NeotestAdapter.build_spec(args)
         name_mappings = name_mappings,
       },
       strategy = dap_strategy(command),
+      stream = stream,
     }
   else
     return {
@@ -226,6 +257,7 @@ function NeotestAdapter.build_spec(args)
         pos_id = position.id,
         name_mappings = name_mappings,
       },
+      stream = stream,
     }
   end
 end
@@ -263,11 +295,13 @@ local iter_test_output_error = function(output)
   end
 end
 
+-- Matches both vanilla minitest verbose output (`Class#m = 0.00 s = .`) and
+-- minitest-reporters' default verbose output (`Class#m 0.40 = .`). The leading
+-- `=` and the `s` time-unit suffix are optional.
+local status_line_pattern = "%s*=?%s*[%d.]+%s*s?%s*=%s*([FE.])"
+
 local iter_test_output_status = function(output)
-  -- Matches both vanilla minitest verbose output (`Class#m = 0.00 s = .`) and
-  -- minitest-reporters' default verbose output (`Class#m 0.40 = .`). The leading
-  -- `=` and the `s` time-unit suffix are optional.
-  local pattern = "%s*=?%s*[%d.]+%s*s?%s*=%s*([FE.])"
+  local pattern = status_line_pattern
 
   -- keep track of last test result position
   local last_pos = 0
@@ -368,6 +402,59 @@ function NeotestAdapter._parse_test_output(output, name_mappings)
   end
 
   return results
+end
+
+-- Builds the iterator passed as `spec.stream` to neotest's runner. Each iteration
+-- consumes the next chunk from `output_stream` (which yields stdout as the test
+-- process emits it), parses any complete lines for per-test status, and returns a
+-- partial results table. Returning nil ends the iteration (process exit / EOF).
+--
+-- Per-test errors and tracebacks are intentionally not surfaced here — they're
+-- multi-line and require the full output to parse safely. NeotestAdapter.results
+-- runs on the captured output file at process exit and fills those in.
+function NeotestAdapter._make_status_stream(name_mappings)
+  return function(output_stream)
+    local buffer = ""
+
+    return function()
+      local data = output_stream()
+      if data == nil then return nil end
+      if type(data) == "table" then data = table.concat(data, "\n") end
+
+      buffer = buffer .. data
+
+      local lines = {}
+      local pos = 1
+      while true do
+        local nl = buffer:find("\n", pos, true)
+        if not nl then break end
+        lines[#lines + 1] = buffer:sub(pos, nl - 1)
+        pos = nl + 1
+      end
+      buffer = buffer:sub(pos)
+
+      local results = {}
+      for _, raw_line in ipairs(lines) do
+        local line = utils.strip_ansi_escape_codes(raw_line)
+        local r_start, _, status = line:find(status_line_pattern)
+        if r_start and status then
+          local test_name = line:sub(1, r_start - 1)
+          local pos_id = name_mappings[test_name]
+          if not pos_id then
+            test_name = utils.replace_module_namespace(test_name)
+            pos_id = name_mappings[test_name]
+          end
+          if pos_id then
+            results[pos_id] = {
+              status = status == "." and "passed" or "failed",
+            }
+          end
+        end
+      end
+
+      return results
+    end
+  end
 end
 
 ---@async

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -96,6 +96,12 @@ function NeotestAdapter.discover_positions(file_path)
       method: (identifier) @func_name (#match? @func_name "^(it)$")
       arguments: (argument_list (string (string_content) @test.name))
     )) @test.definition
+
+    ((
+      call
+      method: (identifier) @func_name (#match? @func_name "^(should)$")
+      arguments: (argument_list (string (string_content) @test.name))
+    )) @test.definition
   ]]
 
   return lib.treesitter.parse_positions(file_path, query, {

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -146,7 +146,7 @@ function NeotestAdapter.build_spec(args)
     local full_spec_name = utils.full_spec_name(args.tree)
     local full_test_name = utils.escaped_full_test_name(args.tree)
     local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
-    local prefix = utils.full_shoulda_prefix(args.tree)
+    local prefixes = utils.full_shoulda_prefixes(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
     -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
@@ -162,10 +162,15 @@ function NeotestAdapter.build_spec(args)
       .. " $"
     -- For shoulda-matchers (`should belong_to(:cycle)`) and `it_requires_*` helpers,
     -- the runtime test name carries a suffix we can't predict from source (matcher
-    -- options or random hex). Append the prefix as an additional alternative — minitest
-    -- uses regex matching for --name, so the prefix matches any test whose name starts
-    -- with it. Over-matches sibling matchers in the same context, which is acceptable.
-    if prefix then pattern = pattern .. "|" .. prefix:gsub("([?])", "\\%1") end
+    -- options or random hex). Append each derived prefix as an additional alternative —
+    -- minitest's --name accepts regex, so the prefix matches any test whose name starts
+    -- with it. Composite helpers like `it_requires_all_auth` yield multiple prefixes so
+    -- running the position runs all of its sub-tests.
+    if prefixes then
+      for _, prefix in ipairs(prefixes) do
+        pattern = pattern .. "|" .. prefix:gsub("([?])", "\\%1")
+      end
+    end
     pattern = pattern .. "/"
     table.insert(script_args, pattern)
   end
@@ -408,9 +413,15 @@ function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mapping
   for test_name, status in iter_test_output_status(output) do
     local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
 
-    if pos_id then results[pos_id] = {
-      status = status == "." and "passed" or "failed",
-    } end
+    if pos_id then
+      local new_status = status == "." and "passed" or "failed"
+      -- Composite helpers like `it_requires_all_auth` map several runtime tests to a
+      -- single pos_id. Preserve "failed" if it was already set so any sub-test failure
+      -- propagates to the line, rather than the last-processed sub-test winning.
+      if not results[pos_id] or results[pos_id].status ~= "failed" then
+        results[pos_id] = { status = new_status }
+      end
+    end
   end
 
   for test_name, filepath, expected, actual in iter_test_output_error(output) do
@@ -484,9 +495,13 @@ function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
           local test_name = line:sub(1, r_start - 1)
           local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
           if pos_id then
-            results[pos_id] = {
-              status = status == "." and "passed" or "failed",
-            }
+            local new_status = status == "." and "passed" or "failed"
+            -- Same "failed sticks" semantic as _parse_test_output; needed so a composite
+            -- helper position that's already failed mid-stream doesn't flip back to
+            -- passed when a later sub-test passes.
+            if not results[pos_id] or results[pos_id].status ~= "failed" then
+              results[pos_id] = { status = new_status }
+            end
           end
         end
       end

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -264,7 +264,10 @@ local iter_test_output_error = function(output)
 end
 
 local iter_test_output_status = function(output)
-  local pattern = "%s*=%s*[%d.]+%s*s%s*=%s*([FE.])"
+  -- Matches both vanilla minitest verbose output (`Class#m = 0.00 s = .`) and
+  -- minitest-reporters' default verbose output (`Class#m 0.40 = .`). The leading
+  -- `=` and the `s` time-unit suffix are optional.
+  local pattern = "%s*=?%s*[%d.]+%s*s?%s*=%s*([FE.])"
 
   -- keep track of last test result position
   local last_pos = 0

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -229,11 +229,11 @@ function NeotestAdapter.build_spec(args)
     cmd_prefix = config.get_test_cmd()
   end
 
-  local command = vim.tbl_flatten({
+  local command = vim.iter({
     cmd_prefix,
     script_args,
     "-v",
-  })
+  }):flatten():totable()
 
   local stream = NeotestAdapter._make_status_stream(name_mappings)
 

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -143,36 +143,40 @@ function NeotestAdapter.build_spec(args)
   end
 
   local function run_by_name()
-    local full_spec_name = utils.full_spec_name(args.tree)
-    local full_test_name = utils.escaped_full_test_name(args.tree)
-    local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
     local run_patterns = utils.full_shoulda_run_patterns(args.tree)
     table.insert(script_args, spec_path)
     table.insert(script_args, "--name")
-    -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
-    -- Shoulda-context method symbols end with a literal space (e.g. :"test_: X should Y. ").
-    -- Minitest compares the filter regex against "#{klass}##{method}", so the suffix
-    -- alternative must end with that trailing space.
-    local pattern = "/^"
-      .. full_spec_name
-      .. "|"
-      .. full_test_name
-      .. "|"
-      .. full_shoulda_test_name
-      .. " $"
-    -- For shoulda-matchers (`should belong_to(:cycle)`) and `it_requires_*` helpers,
-    -- the runtime test name carries a suffix we can't predict from source (matcher
-    -- options or random hex). Append each derived run pattern (`<Class>.*should <desc>`)
-    -- as an additional regex alternative. The `.*` tolerates module-prefixed class names
-    -- in the description that shoulda-context emits for module-scoped classes. Composite
-    -- helpers like `it_requires_all_auth` yield multiple patterns so running the
-    -- position runs all of its sub-tests.
+
+    local pattern
     if run_patterns then
+      -- shoulda-matcher / it_requires_* form: the position name is the matcher source
+      -- expression, which can span multiple lines and contain unbalanced parens, colons,
+      -- quotes, etc. Piping that through full_spec_name / full_test_name /
+      -- full_shoulda_test_name produces malformed regex alternatives that minitest can't
+      -- match against anything (or worse, fails to parse). The runtime test method name
+      -- has no relationship to the source expression for these forms anyway — only the
+      -- description-derived prefix patterns do. Use those alone.
+      local alts = {}
       for _, run_pattern in ipairs(run_patterns) do
-        pattern = pattern .. "|" .. run_pattern:gsub("([?])", "\\%1")
+        table.insert(alts, run_pattern:gsub("([?])", "\\%1"))
       end
+      pattern = "/" .. table.concat(alts, "|") .. "/"
+    else
+      local full_spec_name = utils.full_spec_name(args.tree)
+      local full_test_name = utils.escaped_full_test_name(args.tree)
+      local full_shoulda_test_name = utils.escaped_full_shoulda_test_name(args.tree)
+      -- https://chriskottom.com/articles/command-line-flags-for-minitest-in-the-raw/
+      -- Shoulda-context method symbols end with a literal space (e.g. :"test_: X should
+      -- Y. "). Minitest compares the filter regex against "#{klass}##{method}", so the
+      -- suffix alternative must end with that trailing space.
+      pattern = "/^"
+        .. full_spec_name
+        .. "|"
+        .. full_test_name
+        .. "|"
+        .. full_shoulda_test_name
+        .. " $/"
     end
-    pattern = pattern .. "/"
     table.insert(script_args, pattern)
   end
 

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -158,7 +158,11 @@ function NeotestAdapter.build_spec(args)
       -- description-derived prefix patterns do. Use those alone.
       local alts = {}
       for _, run_pattern in ipairs(run_patterns) do
-        table.insert(alts, run_pattern:gsub("([?])", "\\%1"))
+        -- gsub returns (str, count); wrap in parens so only the string is passed to
+        -- insert (otherwise Lua treats the count as the positional argument and errors
+        -- with "number expected, got string").
+        local escaped = (run_pattern:gsub("([?])", "\\%1"))
+        table.insert(alts, escaped)
       end
       pattern = "/" .. table.concat(alts, "|") .. "/"
     else

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -138,7 +138,7 @@ function NeotestAdapter.build_spec(args)
   local results_path = config.results_path()
   local spec_path = config.transform_spec_path(position.path)
 
-  local name_mappings, prefix_mappings = utils.get_mappings(args.tree)
+  local name_mappings, prefix_mappings, substring_mappings = utils.get_mappings(args.tree)
 
   local function run_by_filename()
     table.insert(script_args, spec_path)
@@ -290,7 +290,7 @@ function NeotestAdapter.build_spec(args)
     "-v",
   }):flatten():totable()
 
-  local stream = NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
+  local stream = NeotestAdapter._make_status_stream(name_mappings, prefix_mappings, substring_mappings)
 
   if args.strategy == "dap" then
     return {
@@ -300,6 +300,7 @@ function NeotestAdapter.build_spec(args)
         pos_id = position.id,
         name_mappings = name_mappings,
         prefix_mappings = prefix_mappings,
+        substring_mappings = substring_mappings,
       },
       strategy = dap_strategy(command),
       stream = stream,
@@ -313,6 +314,7 @@ function NeotestAdapter.build_spec(args)
         pos_id = position.id,
         name_mappings = name_mappings,
         prefix_mappings = prefix_mappings,
+        substring_mappings = substring_mappings,
       },
       stream = stream,
     }
@@ -392,8 +394,12 @@ end
 
 -- Tries an exact lookup in name_mappings first (after stripping module prefixes if
 -- needed). Falls back to scanning prefix_mappings for any prefix that is a literal
--- prefix of the test_name. Returns the matching pos_id or nil.
-local function lookup_pos_id(test_name, name_mappings, prefix_mappings)
+-- prefix of the test_name. Finally falls back to substring_mappings for any substring
+-- (` should <description>.`) that appears anywhere in the test_name — used so a
+-- single source `should "X"` inside an iteration loop maps the N runtime tests it
+-- generates (each with a different interpolated context) to the same position.
+-- Returns the matching pos_id or nil.
+local function lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
   local pos_id = name_mappings[test_name]
   if pos_id then return pos_id end
 
@@ -408,10 +414,18 @@ local function lookup_pos_id(test_name, name_mappings, prefix_mappings)
     end
   end
 
+  if substring_mappings then
+    for substring, sub_pos_id in pairs(substring_mappings) do
+      if test_name:find(substring, 1, true) or stripped:find(substring, 1, true) then
+        return sub_pos_id
+      end
+    end
+  end
+
   return nil
 end
 
-function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mappings)
+function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mappings, substring_mappings)
   local results = {}
   local error_pattern = "Error:%s*([%w:#_]+):%s*(.-)\n[%w%W]-%.rb:(%d+):"
   local traceback_pattern = "(%d+:[^:]+:%d+:in `[^']+')%s+([^:]+):(%d+):(in `[^']+':[^\n]+)"
@@ -432,7 +446,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mapping
   end
 
   for test_name, status in iter_test_output_status(output) do
-    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
 
     if pos_id then
       local new_status = status == "." and "passed" or "failed"
@@ -448,7 +462,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mapping
   for test_name, filepath, expected, actual in iter_test_output_error(output) do
     local message = string.format("Expected: %s\n  Actual: %s", expected, actual)
 
-    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
 
     local line = tonumber(string.match(filepath, ":(%d+)$"))
     if results[pos_id] then
@@ -464,7 +478,7 @@ function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mapping
 
   for test_name, message, line_str in string.gmatch(output, error_pattern) do
     local line = tonumber(line_str)
-    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
+    local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
     if pos_id and results[pos_id] then
       results[pos_id].status = "failed"
       results[pos_id].errors = {
@@ -487,7 +501,7 @@ end
 -- Per-test errors and tracebacks are intentionally not surfaced here — they're
 -- multi-line and require the full output to parse safely. NeotestAdapter.results
 -- runs on the captured output file at process exit and fills those in.
-function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
+function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings, substring_mappings)
   return function(output_stream)
     local buffer = ""
 
@@ -514,7 +528,7 @@ function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings)
         local r_start, _, status = line:find(status_line_pattern)
         if r_start and status then
           local test_name = line:sub(1, r_start - 1)
-          local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings)
+          local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
           if pos_id then
             local new_status = status == "." and "passed" or "failed"
             -- Same "failed sticks" semantic as _parse_test_output; needed so a composite
@@ -548,7 +562,8 @@ function NeotestAdapter.results(spec, result, tree)
   local results = NeotestAdapter._parse_test_output(
     output,
     spec.context.name_mappings,
-    spec.context.prefix_mappings
+    spec.context.prefix_mappings,
+    spec.context.substring_mappings
   )
 
   return results

--- a/lua/neotest-minitest/init.lua
+++ b/lua/neotest-minitest/init.lua
@@ -111,15 +111,6 @@ function NeotestAdapter.discover_positions(file_path)
       method: (identifier) @func_name (#match? @func_name "^(should|should_not)$")
       arguments: (argument_list (call) @test.name)
     )) @test.definition
-
-    ; Project-specific class-method test helpers, e.g. `it_requires_authentication { ... }`.
-    ; The identifier itself is captured as the test name; downstream code derives the
-    ; runtime description (e.g. "require authentication") from the suffix.
-    ((
-      call
-      method: (identifier) @test.name (#match? @test.name "^it_requires_[a-z_]+$")
-      block: (_)
-    )) @test.definition
   ]]
 
   return lib.treesitter.parse_positions(file_path, query, {
@@ -151,13 +142,13 @@ function NeotestAdapter.build_spec(args)
 
     local pattern
     if run_patterns then
-      -- shoulda-matcher / it_requires_* form: the position name is the matcher source
-      -- expression, which can span multiple lines and contain unbalanced parens, colons,
-      -- quotes, etc. Piping that through full_spec_name / full_test_name /
-      -- full_shoulda_test_name produces malformed regex alternatives that minitest can't
-      -- match against anything (or worse, fails to parse). The runtime test method name
-      -- has no relationship to the source expression for these forms anyway — only the
-      -- description-derived prefix patterns do. Use those alone.
+      -- shoulda-matcher form: the position name is the matcher source expression, which
+      -- can span multiple lines and contain unbalanced parens, colons, quotes, etc.
+      -- Piping that through full_spec_name / full_test_name / full_shoulda_test_name
+      -- produces malformed regex alternatives that minitest can't match against anything
+      -- (or worse, fails to parse). The runtime test method name has no relationship to
+      -- the source expression for these forms anyway — only the description-derived
+      -- prefix patterns do. Use those alone.
       local alts = {}
       for _, run_pattern in ipairs(run_patterns) do
         -- gsub returns (str, count); wrap in parens so only the string is passed to
@@ -450,9 +441,9 @@ function NeotestAdapter._parse_test_output(output, name_mappings, prefix_mapping
 
     if pos_id then
       local new_status = status == "." and "passed" or "failed"
-      -- Composite helpers like `it_requires_all_auth` map several runtime tests to a
-      -- single pos_id. Preserve "failed" if it was already set so any sub-test failure
-      -- propagates to the line, rather than the last-processed sub-test winning.
+      -- Iteration-expanded shoulds map several runtime tests to a single pos_id (via
+      -- substring fallback). Preserve "failed" if it was already set so any sub-test
+      -- failure propagates to the line, rather than the last-processed sub-test winning.
       if not results[pos_id] or results[pos_id].status ~= "failed" then
         results[pos_id] = { status = new_status }
       end
@@ -531,9 +522,9 @@ function NeotestAdapter._make_status_stream(name_mappings, prefix_mappings, subs
           local pos_id = lookup_pos_id(test_name, name_mappings, prefix_mappings, substring_mappings)
           if pos_id then
             local new_status = status == "." and "passed" or "failed"
-            -- Same "failed sticks" semantic as _parse_test_output; needed so a composite
-            -- helper position that's already failed mid-stream doesn't flip back to
-            -- passed when a later sub-test passes.
+            -- Same "failed sticks" semantic as _parse_test_output; needed so an
+            -- iteration-expanded position that's already failed mid-stream doesn't flip
+            -- back to passed when a later sub-test passes.
             if not results[pos_id] or results[pos_id].status ~= "failed" then
               results[pos_id] = { status = new_status }
             end

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -100,6 +100,8 @@ M.full_test_name = function(tree)
   return parent_name .. "#" .. name:gsub(" ", "_")
 end
 
+-- Returns the shoulda-context method name WITHOUT the trailing space that's part of
+-- the Ruby symbol — callers using this for an --name regex append " $" themselves.
 M.full_shoulda_test_name = function(tree)
   local name = tree:data().name
   local namespaces = {}
@@ -130,6 +132,13 @@ end
 M.escaped_full_test_name = function(tree)
   local full_name = M.full_test_name(tree)
   return full_name:gsub("([?#])", "\\%1")
+end
+
+M.escaped_full_shoulda_test_name = function(tree)
+  -- `#` is the structural separator between class and method name, so it must remain
+  -- literal in the regex. `?` is the only regex metachar that can appear in user-authored
+  -- shoulda descriptions, so we escape it.
+  return M.full_shoulda_test_name(tree):gsub("([?])", "\\%1")
 end
 
 M.get_mappings = function(tree)

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -293,6 +293,28 @@ M.full_shoulda_prefix = function(tree)
   return prefixes and prefixes[1] or nil
 end
 
+-- Returns a single permissive `<ShortClass>.*should <name>` regex pattern. Used as an
+-- additional alternative in run_by_name's --name filter to tolerate module prefixes that
+-- shoulda-context injects into the description of class-level string-form shoulds
+-- (e.g. for `module Foo; class BarTest`, shoulda emits `Foo::BarTest#test_: Foo::Bar
+-- should X` and our literal `BarTest#test_: Bar should X` doesn't match as a substring).
+M.permissive_should_pattern = function(tree)
+  local data = tree:data()
+  if data.type ~= "test" then return nil end
+
+  local class_name
+  for parent_node in tree:iter_parents() do
+    if parent_node:data().type == "namespace" then
+      class_name = parent_node:data().name
+    else
+      break
+    end
+  end
+  if not class_name then return nil end
+
+  return class_name .. ".*should " .. data.name
+end
+
 -- Returns regex patterns suitable for minitest's `--name <regex>` filter for the same
 -- positions full_shoulda_prefixes covers. Differs in two ways: it uses `.*` between the
 -- short class name and the description to tolerate module prefixes that shoulda-context

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -100,6 +100,33 @@ M.full_test_name = function(tree)
   return parent_name .. "#" .. name:gsub(" ", "_")
 end
 
+M.full_shoulda_test_name = function(tree)
+  local name = tree:data().name
+  local namespaces = {}
+
+  for parent_node in tree:iter_parents() do
+    local data = parent_node:data()
+    if data.type == "namespace" then
+      table.insert(namespaces, 1, data.name)
+    else
+      break
+    end
+  end
+
+  if #namespaces == 0 then return name end
+
+  local class_name = table.remove(namespaces, 1)
+
+  local chain
+  if #namespaces == 0 then
+    chain = class_name:gsub("Test$", "")
+  else
+    chain = table.concat(namespaces, " ")
+  end
+
+  return class_name .. "#test_: " .. chain .. " should " .. name .. "."
+end
+
 M.escaped_full_test_name = function(tree)
   local full_name = M.full_test_name(tree)
   return full_name:gsub("([?#])", "\\%1")

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -141,9 +141,101 @@ M.escaped_full_shoulda_test_name = function(tree)
   return M.full_shoulda_test_name(tree):gsub("([?])", "\\%1")
 end
 
+-- shoulda-matchers description prefixes for matchers commonly used in Rails apps.
+-- The returned string is the head of `matcher.description` — the runtime test method
+-- name appends suffix text per matcher option (e.g. `optional: true`,
+-- `class_name => Foo`), so we match by prefix rather than exact name.
+local SHOULDA_MATCHERS = {
+  belong_to = function(arg) return "belong to " .. arg end,
+  have_many = function(arg) return "have many " .. arg end,
+  have_one = function(arg) return "have one " .. arg end,
+  have_and_belong_to_many = function(arg) return "have and belong to many " .. arg end,
+  validate_presence_of = function(arg) return "validate that :" .. arg end,
+  validate_uniqueness_of = function(arg) return "validate that :" .. arg end,
+  validate_length_of = function(arg) return "validate that the length of :" .. arg end,
+  validate_inclusion_of = function(arg) return "validate that :" .. arg end,
+  validate_numericality_of = function(arg) return "validate that :" .. arg end,
+  validate_acceptance_of = function(arg) return "validate that :" .. arg end,
+  validate_absence_of = function(arg) return "validate that :" .. arg end,
+  validate_format_of = function(arg) return "validate that :" .. arg end,
+  define_enum_for = function(arg) return "define :" .. arg end,
+  delegate_method = function(arg) return "delegate method ##{" .. arg end,
+  have_db_column = function(arg) return "have db column named " .. arg end,
+  have_db_index = function(arg) return "have a db index on " .. arg end,
+  have_readonly_attribute = function(arg) return "have readonly attribute " .. arg end,
+  have_secure_password = function() return "have a secure password" end,
+  serialize = function(arg) return "serialize :" .. arg end,
+  accept_nested_attributes_for = function(arg) return "accept nested attributes for " .. arg end,
+}
+
+-- Given the source text of a `should <call>` argument like `belong_to(:cycle).optional(true)`,
+-- returns the description prefix that shoulda-matchers will use for the generated test
+-- method, or nil if the matcher isn't recognized. Only the head of the chain is consumed —
+-- chained options contribute additional suffix text that's allowed to vary at match time.
+M.shoulda_matcher_prefix = function(name)
+  local matcher, arg = name:match("^([%w_]+)%(:?([%w_]+)")
+  if matcher then
+    local builder = SHOULDA_MATCHERS[matcher]
+    if builder then return builder(arg) end
+  end
+
+  -- `have_secure_password` and other no-arg matchers
+  local no_arg = name:match("^([%w_]+)%(%)")
+  if no_arg and SHOULDA_MATCHERS[no_arg] then return SHOULDA_MATCHERS[no_arg]() end
+
+  return nil
+end
+
+-- `it_requires_authentication` → "require authentication", and similar.
+M.it_requires_helper_prefix = function(name)
+  local suffix = name:match("^it_requires_(.+)$")
+  if not suffix then return nil end
+  return "require " .. suffix:gsub("_", " ")
+end
+
+-- Returns the expected runtime-method prefix for a tree position whose `name` is either
+-- a shoulda-matchers expression or an `it_requires_*` identifier. The prefix is the full
+-- `<Class>#test_: <chain> should <description>` head; callers do `string.sub`-style prefix
+-- matching against minitest verbose output to identify the runtime test, ignoring any
+-- per-call suffix (matcher options or random hex).
+M.full_shoulda_prefix = function(tree)
+  local data = tree:data()
+  local description
+  if data.name:match("^it_requires_") then
+    description = M.it_requires_helper_prefix(data.name)
+  else
+    description = M.shoulda_matcher_prefix(data.name)
+  end
+  if not description then return nil end
+
+  local namespaces = {}
+  for parent_node in tree:iter_parents() do
+    if parent_node:data().type == "namespace" then
+      table.insert(namespaces, 1, parent_node:data().name)
+    else
+      break
+    end
+  end
+  if #namespaces == 0 then return nil end
+
+  local class_name = table.remove(namespaces, 1)
+  local chain
+  if #namespaces == 0 then
+    chain = class_name:gsub("Test$", "")
+  else
+    chain = table.concat(namespaces, " ")
+  end
+
+  return class_name .. "#test_: " .. chain .. " should " .. description
+end
+
 M.get_mappings = function(tree)
-  -- get the mappings for the current node and its children
+  -- Returns two tables. `mappings` is exact-match `runtime_name -> pos_id`. `prefixes`
+  -- maps a prefix string to a pos_id and is consulted only after exact lookup fails —
+  -- used for shoulda-matchers and `it_requires_*` helpers whose runtime method names
+  -- carry a varying suffix (matcher options or random hex).
   local mappings = {}
+  local prefixes = {}
   local function name_map(tree)
     local data = tree:data()
     if data.type == "test" then
@@ -155,6 +247,9 @@ M.get_mappings = function(tree)
 
       local full_shoulda_test_name = M.full_shoulda_test_name(tree)
       mappings[full_shoulda_test_name] = data.id
+
+      local prefix = M.full_shoulda_prefix(tree)
+      if prefix then prefixes[prefix] = data.id end
     end
 
     for _, child in ipairs(tree:children()) do
@@ -163,7 +258,7 @@ M.get_mappings = function(tree)
   end
   name_map(tree)
 
-  return mappings
+  return mappings, prefixes
 end
 
 M.strip_ansi_escape_codes = function(str)

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -258,6 +258,40 @@ M.full_shoulda_prefix = function(tree)
   return prefixes and prefixes[1] or nil
 end
 
+-- Returns regex patterns suitable for minitest's `--name <regex>` filter for the same
+-- positions full_shoulda_prefixes covers. Differs in two ways: it uses `.*` between the
+-- short class name and the description to tolerate module prefixes that shoulda-context
+-- injects when the test class is module-scoped (e.g. shoulda emits
+-- `MyProfile::Foo should bar` for a class-level should inside `module MyProfile`), and
+-- it omits the structural `#test_:` separator since the `.*` swallows it.
+M.full_shoulda_run_patterns = function(tree)
+  local data = tree:data()
+  local descriptions
+  if data.name:match("^it_requires_") then
+    descriptions = M.it_requires_helper_prefixes(data.name)
+  else
+    local single = M.shoulda_matcher_prefix(data.name)
+    descriptions = single and { single } or nil
+  end
+  if not descriptions then return nil end
+
+  local class_name
+  for parent_node in tree:iter_parents() do
+    if parent_node:data().type == "namespace" then
+      class_name = parent_node:data().name
+    else
+      break
+    end
+  end
+  if not class_name then return nil end
+
+  local out = {}
+  for _, description in ipairs(descriptions) do
+    table.insert(out, class_name .. ".*should " .. description)
+  end
+  return out
+end
+
 M.get_mappings = function(tree)
   -- Returns two tables. `mappings` is exact-match `runtime_name -> pos_id`. `prefixes`
   -- maps a prefix string to a pos_id and is consulted only after exact lookup fails —

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -168,22 +168,55 @@ local SHOULDA_MATCHERS = {
   accept_nested_attributes_for = function(arg) return "accepts_nested_attributes_for :" .. arg end,
   have_many_attached = function(arg) return "have a has_many_attached called " .. arg end,
   have_one_attached = function(arg) return "have a has_one_attached called " .. arg end,
+  normalize = function(arg) return "normalize " .. arg end,
 }
 
--- Given the source text of a `should <call>` argument like `belong_to(:cycle).optional(true)`,
--- returns the description prefix that shoulda-matchers will use for the generated test
--- method, or nil if the matcher isn't recognized. Only the head of the chain is consumed —
--- chained options contribute additional suffix text that's allowed to vary at match time.
+-- shoulda-matchers' allow_value matcher takes the attribute in a separate `.for(:X)`
+-- chain rather than as the head argument, and the value being checked is a Ruby
+-- literal (string / nil / number) shoulda formats by wrapping in single guillemets.
+-- Source: `allow_value("foo").for(:bar)` → description: `allow :bar to be ‹"foo"›`.
+-- Returns nil if the source doesn't look like an allow_value chain.
+local function allow_value_prefix(name)
+  if not name:match("^allow_value%(") then return nil end
+  local literal = name:match("^allow_value%((.-)%)")
+  local attr = name:match("%.for%(:?([%w_]+)%)")
+  if not literal or not attr then return nil end
+  return "allow :" .. attr .. " to be \xE2\x80\xB9" .. literal .. "\xE2\x80\xBA"
+end
+
+-- Given the source text of a `should <call>` (or `should_not <call>`) argument like
+-- `belong_to(:cycle).optional(true)`, returns the description prefix that shoulda-matchers
+-- will use for the generated test method, or nil if the matcher isn't recognized.
+-- Only the head of the chain is consumed — chained options contribute additional suffix
+-- text that's allowed to vary at match time. A leading `not ` marker (added by
+-- M.build_position when the wrapping call is `should_not`) is stripped and re-applied
+-- after the matcher's description is built.
 M.shoulda_matcher_prefix = function(name)
+  local negated = false
+  if name:sub(1, 4) == "not " then
+    negated = true
+    name = name:sub(5)
+  end
+
+  local function negate(desc)
+    if not desc then return nil end
+    if negated then return "not " .. desc end
+    return desc
+  end
+
+  -- allow_value(<literal>).for(:attr) — attribute is in the chain, not the head call.
+  local allow = allow_value_prefix(name)
+  if allow then return negate(allow) end
+
   local matcher, arg = name:match("^([%w_]+)%(:?([%w_]+)")
   if matcher then
     local builder = SHOULDA_MATCHERS[matcher]
-    if builder then return builder(arg) end
+    if builder then return negate(builder(arg)) end
   end
 
   -- `have_secure_password` and other no-arg matchers
   local no_arg = name:match("^([%w_]+)%(%)")
-  if no_arg and SHOULDA_MATCHERS[no_arg] then return SHOULDA_MATCHERS[no_arg]() end
+  if no_arg and SHOULDA_MATCHERS[no_arg] then return negate(SHOULDA_MATCHERS[no_arg]()) end
 
   return nil
 end
@@ -328,6 +361,36 @@ M.get_mappings = function(tree)
   name_map(tree)
 
   return mappings, prefixes
+end
+
+-- Custom build_position that detects shoulda-context's `should_not <matcher>` form by
+-- inspecting the @func_name capture in the treesitter match. When found, the captured
+-- matcher source is prefixed with `not ` so the same prefix-derivation logic that handles
+-- positive shoulda-matchers can branch on the marker (see M.shoulda_matcher_prefix).
+-- Otherwise delegates to neotest's standard match-type detection.
+M.build_position = function(file_path, source, captured_nodes, _metadata)
+  local match_type
+  if captured_nodes["test.name"] then
+    match_type = "test"
+  elseif captured_nodes["namespace.name"] then
+    match_type = "namespace"
+  end
+  if not match_type then return end
+
+  local name = vim.treesitter.get_node_text(captured_nodes[match_type .. ".name"], source)
+  local definition = captured_nodes[match_type .. ".definition"]
+
+  if match_type == "test" and captured_nodes.func_name then
+    local func_text = vim.treesitter.get_node_text(captured_nodes.func_name, source)
+    if func_text == "should_not" then name = "not " .. name end
+  end
+
+  return {
+    type = match_type,
+    path = file_path,
+    name = name,
+    range = { definition:range() },
+  }
 end
 
 M.strip_ansi_escape_codes = function(str)

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -165,7 +165,7 @@ local SHOULDA_MATCHERS = {
   have_readonly_attribute = function(arg) return "have readonly attribute " .. arg end,
   have_secure_password = function() return "have a secure password" end,
   serialize = function(arg) return "serialize :" .. arg end,
-  accept_nested_attributes_for = function(arg) return "accept nested attributes for " .. arg end,
+  accept_nested_attributes_for = function(arg) return "accepts_nested_attributes_for :" .. arg end,
   have_many_attached = function(arg) return "have a has_many_attached called " .. arg end,
   have_one_attached = function(arg) return "have a has_one_attached called " .. arg end,
 }

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -186,27 +186,43 @@ M.shoulda_matcher_prefix = function(name)
   return nil
 end
 
--- `it_requires_authentication` → "require authentication", and similar.
-M.it_requires_helper_prefix = function(name)
+-- Returns a list of description prefixes for an `it_requires_*` identifier.
+-- Most helpers map to a single prefix (e.g. `it_requires_authentication` → `require
+-- authentication`). Composites like `it_requires_all_auth` are project conventions that
+-- internally call several sub-helpers — one source line produces multiple runtime tests
+-- — so we register a prefix per sub-helper, all pointing at the same position id. A run
+-- of the line passes only when all sub-tests pass; failing any one marks the line failed.
+M.it_requires_helper_prefixes = function(name)
   local suffix = name:match("^it_requires_(.+)$")
   if not suffix then return nil end
-  return "require " .. suffix:gsub("_", " ")
+
+  if suffix == "all_auth" then
+    return {
+      "require authentication",
+      "require authorization",
+      "require permission",
+    }
+  end
+
+  return { "require " .. suffix:gsub("_", " ") }
 end
 
--- Returns the expected runtime-method prefix for a tree position whose `name` is either
--- a shoulda-matchers expression or an `it_requires_*` identifier. The prefix is the full
--- `<Class>#test_: <chain> should <description>` head; callers do `string.sub`-style prefix
--- matching against minitest verbose output to identify the runtime test, ignoring any
--- per-call suffix (matcher options or random hex).
-M.full_shoulda_prefix = function(tree)
+-- Returns the list of expected runtime-method prefixes for a tree position whose `name`
+-- is either a shoulda-matchers expression or an `it_requires_*` identifier. Most positions
+-- produce one prefix; composite helpers produce several. Each prefix is the full
+-- `<Class>#test_: <chain> should <description>` head; callers do prefix matching against
+-- minitest verbose output to identify the runtime test, ignoring any per-call suffix
+-- (matcher options or random hex).
+M.full_shoulda_prefixes = function(tree)
   local data = tree:data()
-  local description
+  local descriptions
   if data.name:match("^it_requires_") then
-    description = M.it_requires_helper_prefix(data.name)
+    descriptions = M.it_requires_helper_prefixes(data.name)
   else
-    description = M.shoulda_matcher_prefix(data.name)
+    local single = M.shoulda_matcher_prefix(data.name)
+    descriptions = single and { single } or nil
   end
-  if not description then return nil end
+  if not descriptions then return nil end
 
   local namespaces = {}
   for parent_node in tree:iter_parents() do
@@ -226,7 +242,20 @@ M.full_shoulda_prefix = function(tree)
     chain = table.concat(namespaces, " ")
   end
 
-  return class_name .. "#test_: " .. chain .. " should " .. description
+  local head = class_name .. "#test_: " .. chain .. " should "
+  local out = {}
+  for _, description in ipairs(descriptions) do
+    table.insert(out, head .. description)
+  end
+  return out
+end
+
+-- Backward-compatible singular form: returns the first prefix or nil. Kept for callers
+-- that build a single regex alternative (e.g. run_by_name); when a position has multiple
+-- prefixes, callers that need them all should switch to full_shoulda_prefixes.
+M.full_shoulda_prefix = function(tree)
+  local prefixes = M.full_shoulda_prefixes(tree)
+  return prefixes and prefixes[1] or nil
 end
 
 M.get_mappings = function(tree)
@@ -248,8 +277,12 @@ M.get_mappings = function(tree)
       local full_shoulda_test_name = M.full_shoulda_test_name(tree)
       mappings[full_shoulda_test_name] = data.id
 
-      local prefix = M.full_shoulda_prefix(tree)
-      if prefix then prefixes[prefix] = data.id end
+      local position_prefixes = M.full_shoulda_prefixes(tree)
+      if position_prefixes then
+        for _, prefix in ipairs(position_prefixes) do
+          prefixes[prefix] = data.id
+        end
+      end
     end
 
     for _, child in ipairs(tree:children()) do

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -166,6 +166,8 @@ local SHOULDA_MATCHERS = {
   have_secure_password = function() return "have a secure password" end,
   serialize = function(arg) return "serialize :" .. arg end,
   accept_nested_attributes_for = function(arg) return "accept nested attributes for " .. arg end,
+  have_many_attached = function(arg) return "have a has_many_attached called " .. arg end,
+  have_one_attached = function(arg) return "have a has_one_attached called " .. arg end,
 }
 
 -- Given the source text of a `should <call>` argument like `belong_to(:cycle).optional(true)`,

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -143,6 +143,9 @@ M.get_mappings = function(tree)
 
       local full_test_name = M.full_test_name(tree)
       mappings[full_test_name] = data.id
+
+      local full_shoulda_test_name = M.full_shoulda_test_name(tree)
+      mappings[full_shoulda_test_name] = data.id
     end
 
     for _, child in ipairs(tree:children()) do

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -350,12 +350,21 @@ M.full_shoulda_run_patterns = function(tree)
 end
 
 M.get_mappings = function(tree)
-  -- Returns two tables. `mappings` is exact-match `runtime_name -> pos_id`. `prefixes`
-  -- maps a prefix string to a pos_id and is consulted only after exact lookup fails —
-  -- used for shoulda-matchers and `it_requires_*` helpers whose runtime method names
-  -- carry a varying suffix (matcher options or random hex).
+  -- Returns three tables consulted by lookup_pos_id in order:
+  --   * `mappings`   — exact `runtime_name -> pos_id`.
+  --   * `prefixes`   — `runtime_prefix -> pos_id`; matched as a literal prefix of the
+  --                    runtime name. Used for shoulda-matchers / it_requires_* whose
+  --                    runtime names carry a varying suffix (matcher options, random hex).
+  --   * `substrings` — `" should <name>." -> pos_id`; matched as a substring anywhere in
+  --                    the runtime name. Used to map iteration-expanded should tests where
+  --                    the context name is interpolated (e.g. `OPTIONS.each do |type|;
+  --                    context "given a(n) #{type}..." do should "X" do end end end`) and
+  --                    several runtime methods share the same description but different
+  --                    context chains. All N iterations land on the same position; "failed
+  --                    sticks" aggregation gives the position the worst-case status.
   local mappings = {}
   local prefixes = {}
+  local substrings = {}
   local function name_map(tree)
     local data = tree:data()
     if data.type == "test" then
@@ -374,6 +383,15 @@ M.get_mappings = function(tree)
           prefixes[prefix] = data.id
         end
       end
+
+      -- Register a substring fallback only for plain string-form `should "X"` positions
+      -- (skip matcher/helper forms, which have their own prefix infrastructure).
+      if not data.name:match("^it_requires_")
+        and not data.name:match("^not it_requires_")
+        and not M.shoulda_matcher_prefix(data.name)
+      then
+        substrings[" should " .. data.name .. "."] = data.id
+      end
     end
 
     for _, child in ipairs(tree:children()) do
@@ -382,7 +400,7 @@ M.get_mappings = function(tree)
   end
   name_map(tree)
 
-  return mappings, prefixes
+  return mappings, prefixes, substrings
 end
 
 -- Custom build_position that detects shoulda-context's `should_not <matcher>` form by

--- a/lua/neotest-minitest/utils.lua
+++ b/lua/neotest-minitest/utils.lua
@@ -221,42 +221,14 @@ M.shoulda_matcher_prefix = function(name)
   return nil
 end
 
--- Returns a list of description prefixes for an `it_requires_*` identifier.
--- Most helpers map to a single prefix (e.g. `it_requires_authentication` → `require
--- authentication`). Composites like `it_requires_all_auth` are project conventions that
--- internally call several sub-helpers — one source line produces multiple runtime tests
--- — so we register a prefix per sub-helper, all pointing at the same position id. A run
--- of the line passes only when all sub-tests pass; failing any one marks the line failed.
-M.it_requires_helper_prefixes = function(name)
-  local suffix = name:match("^it_requires_(.+)$")
-  if not suffix then return nil end
-
-  if suffix == "all_auth" then
-    return {
-      "require authentication",
-      "require authorization",
-      "require permission",
-    }
-  end
-
-  return { "require " .. suffix:gsub("_", " ") }
-end
-
--- Returns the list of expected runtime-method prefixes for a tree position whose `name`
--- is either a shoulda-matchers expression or an `it_requires_*` identifier. Most positions
--- produce one prefix; composite helpers produce several. Each prefix is the full
--- `<Class>#test_: <chain> should <description>` head; callers do prefix matching against
--- minitest verbose output to identify the runtime test, ignoring any per-call suffix
--- (matcher options or random hex).
+-- Returns the list of expected runtime-method prefixes for a shoulda-matchers test
+-- position. Each prefix is the full `<Class>#test_: <chain> should <description>` head;
+-- callers do prefix matching against minitest verbose output to identify the runtime
+-- test, ignoring any per-call suffix (matcher options).
 M.full_shoulda_prefixes = function(tree)
   local data = tree:data()
-  local descriptions
-  if data.name:match("^it_requires_") then
-    descriptions = M.it_requires_helper_prefixes(data.name)
-  else
-    local single = M.shoulda_matcher_prefix(data.name)
-    descriptions = single and { single } or nil
-  end
+  local single = M.shoulda_matcher_prefix(data.name)
+  local descriptions = single and { single } or nil
   if not descriptions then return nil end
 
   local namespaces = {}
@@ -323,13 +295,8 @@ end
 -- it omits the structural `#test_:` separator since the `.*` swallows it.
 M.full_shoulda_run_patterns = function(tree)
   local data = tree:data()
-  local descriptions
-  if data.name:match("^it_requires_") then
-    descriptions = M.it_requires_helper_prefixes(data.name)
-  else
-    local single = M.shoulda_matcher_prefix(data.name)
-    descriptions = single and { single } or nil
-  end
+  local single = M.shoulda_matcher_prefix(data.name)
+  local descriptions = single and { single } or nil
   if not descriptions then return nil end
 
   local class_name
@@ -353,8 +320,8 @@ M.get_mappings = function(tree)
   -- Returns three tables consulted by lookup_pos_id in order:
   --   * `mappings`   — exact `runtime_name -> pos_id`.
   --   * `prefixes`   — `runtime_prefix -> pos_id`; matched as a literal prefix of the
-  --                    runtime name. Used for shoulda-matchers / it_requires_* whose
-  --                    runtime names carry a varying suffix (matcher options, random hex).
+  --                    runtime name. Used for shoulda-matchers whose runtime names carry
+  --                    a varying suffix (chained options like `optional: true`).
   --   * `substrings` — `" should <name>." -> pos_id`; matched as a substring anywhere in
   --                    the runtime name. Used to map iteration-expanded should tests where
   --                    the context name is interpolated (e.g. `OPTIONS.each do |type|;
@@ -385,11 +352,8 @@ M.get_mappings = function(tree)
       end
 
       -- Register a substring fallback only for plain string-form `should "X"` positions
-      -- (skip matcher/helper forms, which have their own prefix infrastructure).
-      if not data.name:match("^it_requires_")
-        and not data.name:match("^not it_requires_")
-        and not M.shoulda_matcher_prefix(data.name)
-      then
+      -- (skip matcher forms, which have their own prefix infrastructure).
+      if not M.shoulda_matcher_prefix(data.name) then
         substrings[" should " .. data.name .. "."] = data.id
       end
     end

--- a/tests/adapter/rails_unit_spec.lua
+++ b/tests/adapter/rails_unit_spec.lua
@@ -161,6 +161,71 @@ Expected: 4
       end)
     end)
 
+    describe("_make_status_stream", function()
+      local function make_output_stream(chunks)
+        local i = 0
+        return function()
+          i = i + 1
+          return chunks[i]
+        end
+      end
+
+      it("emits results as lines arrive across chunks", function()
+        local stream = plugin._make_status_stream({
+          ["UserMailerTest#test_one"] = "pos1",
+          ["UserMailerTest#test_two"] = "pos2",
+        })
+        local iter = stream(make_output_stream({
+          "UserMailerTest#test_one 0.01 = .\n",
+          "UserMailerTest#test_two 0.02 = F\n",
+        }))
+
+        assert.are.same({ pos1 = { status = "passed" } }, iter())
+        assert.are.same({ pos2 = { status = "failed" } }, iter())
+        assert.is_nil(iter())
+      end)
+
+      it("buffers partial lines across chunks", function()
+        local stream = plugin._make_status_stream({
+          ["UserMailerTest#test_split"] = "pos1",
+        })
+        local iter = stream(make_output_stream({
+          "UserMailerTest#test_sp",
+          "lit 0.01 = .\n",
+        }))
+
+        assert.are.same({}, iter())
+        assert.are.same({ pos1 = { status = "passed" } }, iter())
+      end)
+
+      it("parses vanilla minitest format as well as minitest-reporters", function()
+        local stream = plugin._make_status_stream({
+          ["UserMailerTest#test_vanilla"] = "pos1",
+          ["UserMailerTest#test_reporters"] = "pos2",
+        })
+        local iter = stream(make_output_stream({
+          "UserMailerTest#test_vanilla = 0.00 s = .\n" ..
+          "UserMailerTest#test_reporters 0.40 = .\n",
+        }))
+
+        assert.are.same({
+          pos1 = { status = "passed" },
+          pos2 = { status = "passed" },
+        }, iter())
+      end)
+
+      it("falls back to module-namespace stripping for module-prefixed test names", function()
+        local stream = plugin._make_status_stream({
+          ["UserMailerTest#test_one"] = "pos1",
+        })
+        local iter = stream(make_output_stream({
+          "Foo::Bar::UserMailerTest#test_one 0.01 = .\n",
+        }))
+
+        assert.are.same({ pos1 = { status = "passed" } }, iter())
+      end)
+    end)
+
     describe("minitest-reporters verbose format", function()
       local output = [[
 UserMailerTest#test_password_reset_without_patient_or_account_user 0.40 = .

--- a/tests/adapter/rails_unit_spec.lua
+++ b/tests/adapter/rails_unit_spec.lua
@@ -161,6 +161,30 @@ Expected: 4
       end)
     end)
 
+    describe("minitest-reporters verbose format", function()
+      local output = [[
+UserMailerTest#test_password_reset_without_patient_or_account_user 0.40 = .
+UserMailerTest#test_password_reset_with_patient_includes_account_name 0.05 = F
+
+
+Failure:
+UserMailerTest#test_password_reset_with_patient_includes_account_name [/path/to/tests/minitest_examples/rails_unit_test.rb:17]:
+Expected: "Sample Clinic account password reset request"
+  Actual: "Wrong subject"
+
+      ]]
+
+      it("parses passing and failing tests in minitest-reporters output", function()
+        local results = plugin._parse_test_output(output, {
+          ["UserMailerTest#test_password_reset_without_patient_or_account_user"] = "pos_pass",
+          ["UserMailerTest#test_password_reset_with_patient_includes_account_name"] = "pos_fail",
+        })
+
+        assert.equal("passed", results["pos_pass"].status)
+        assert.equal("failed", results["pos_fail"].status)
+      end)
+    end)
+
     describe("multiple failing tests", function()
       local output = [[
 RailsUnitTest#test_adds_two_numbers = 0.00 s = F

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -60,8 +60,8 @@ describe("Shoulda Test", function()
   describe("_parse_test_output", function()
     it("maps shoulda-format output lines to position ids", function()
       local output = [[
-ShouldaTest#test_: Shoulda should do a thing. = 0.00 s = .
-ShouldaTest#test_: addition should add two numbers. = 0.00 s = .
+ShouldaTest#test_: Shoulda should do a thing.  = 0.00 s = .
+ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
       ]]
 
       local results = plugin._parse_test_output(output, {

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -74,5 +74,33 @@ ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
         ["pos_nested"] = { status = "passed" },
       }, results)
     end)
+
+    it("falls back to prefix matching for shoulda-matchers", function()
+      local output =
+        "Patients::Cycles::TissueTest#test_: associations should belong to cycle optional: true.  = 0.04 s = .\n"
+        .. "Patients::Cycles::TissueTest#test_: enums should define :current_disposition as an enum backed by an enum.  = 0.04 s = F\n"
+
+      local results = plugin._parse_test_output(output, {}, {
+        ["TissueTest#test_: associations should belong to cycle"] = "pos_belong",
+        ["TissueTest#test_: enums should define :current_disposition"] = "pos_enum",
+      })
+
+      assert.equal("passed", results["pos_belong"].status)
+      assert.equal("failed", results["pos_enum"].status)
+    end)
+
+    it("falls back to prefix matching for it_requires_* helpers (with random hex suffix)", function()
+      local output =
+        "TissueObservationsControllerTest#test_: update should require authentication - bd6bdc1bd62ef5d7c386a77f.  = 0.05 s = F\n"
+        .. "TissueObservationsControllerTest#test_: update should require authorization - d0544478e23d1b87104cee3e.  = 0.08 s = .\n"
+
+      local results = plugin._parse_test_output(output, {}, {
+        ["TissueObservationsControllerTest#test_: update should require authentication"] = "pos_authn",
+        ["TissueObservationsControllerTest#test_: update should require authorization"] = "pos_authz",
+      })
+
+      assert.equal("failed", results["pos_authn"].status)
+      assert.equal("passed", results["pos_authz"].status)
+    end)
   end)
 end)

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -56,4 +56,23 @@ describe("Shoulda Test", function()
       assert.are.same(expected_positions, positions)
     end)
   end)
+
+  describe("_parse_test_output", function()
+    it("maps shoulda-format output lines to position ids", function()
+      local output = [[
+ShouldaTest#test_: Shoulda should do a thing. = 0.00 s = .
+ShouldaTest#test_: addition should add two numbers. = 0.00 s = .
+      ]]
+
+      local results = plugin._parse_test_output(output, {
+        ["ShouldaTest#test_: Shoulda should do a thing."] = "pos_top",
+        ["ShouldaTest#test_: addition should add two numbers."] = "pos_nested",
+      })
+
+      assert.are.same({
+        ["pos_top"] = { status = "passed" },
+        ["pos_nested"] = { status = "passed" },
+      }, results)
+    end)
+  end)
 end)

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -1,0 +1,59 @@
+local plugin = require("neotest-minitest")
+local async = require("nio.tests")
+
+describe("Shoulda Test", function()
+  assert:set_parameter("TableFormatLevel", -1)
+  describe("discover_positions", function()
+    async.it("discovers should declarations at class level and inside context", function()
+      local test_path = vim.loop.cwd() .. "/tests/minitest_examples/shoulda_test.rb"
+      local positions = plugin.discover_positions(test_path):to_list()
+      local expected_positions = {
+        {
+          id = test_path,
+          name = "shoulda_test.rb",
+          path = test_path,
+          range = { 0, 0, 17, 0 },
+          type = "file",
+        },
+        {
+          {
+            id = "./tests/minitest_examples/shoulda_test.rb::7",
+            name = "ShouldaTest",
+            path = test_path,
+            range = { 6, 0, 16, 3 },
+            type = "namespace",
+          },
+          {
+            {
+              id = "./tests/minitest_examples/shoulda_test.rb::8",
+              name = "do a thing",
+              path = test_path,
+              range = { 7, 2, 9, 5 },
+              type = "test",
+            },
+          },
+          {
+            {
+              id = "./tests/minitest_examples/shoulda_test.rb::12",
+              name = "addition",
+              path = test_path,
+              range = { 11, 2, 15, 5 },
+              type = "namespace",
+            },
+            {
+              {
+                id = "./tests/minitest_examples/shoulda_test.rb::13",
+                name = "add two numbers",
+                path = test_path,
+                range = { 12, 4, 14, 7 },
+                type = "test",
+              },
+            },
+          },
+        },
+      }
+
+      assert.are.same(expected_positions, positions)
+    end)
+  end)
+end)

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -102,5 +102,28 @@ ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
       assert.equal("failed", results["pos_authn"].status)
       assert.equal("passed", results["pos_authz"].status)
     end)
+
+    it("marks a single it_requires_all_auth position based on any of its three sub-tests", function()
+      -- All three sub-helpers map to the same pos id; if any fails, the line stays failed.
+      local prefixes = {
+        ["ControllerTest#test_: update should require authentication"] = "pos_all",
+        ["ControllerTest#test_: update should require authorization"] = "pos_all",
+        ["ControllerTest#test_: update should require permission"] = "pos_all",
+      }
+
+      local passing_output =
+        "ControllerTest#test_: update should require authentication - aaa111.  = 0.05 s = .\n"
+        .. "ControllerTest#test_: update should require authorization - bbb222.  = 0.05 s = .\n"
+        .. "ControllerTest#test_: update should require permission - ccc333.  = 0.05 s = .\n"
+      assert.equal("passed", plugin._parse_test_output(passing_output, {}, prefixes)["pos_all"].status)
+
+      -- Mixed: one sub-test fails. The parser must report failed regardless of which
+      -- sub-test fails and where it appears in the output.
+      local mixed_output =
+        "ControllerTest#test_: update should require authentication - aaa111.  = 0.05 s = .\n"
+        .. "ControllerTest#test_: update should require authorization - bbb222.  = 0.05 s = F\n"
+        .. "ControllerTest#test_: update should require permission - ccc333.  = 0.05 s = .\n"
+      assert.equal("failed", plugin._parse_test_output(mixed_output, {}, prefixes)["pos_all"].status)
+    end)
   end)
 end)

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -89,20 +89,6 @@ ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
       assert.equal("failed", results["pos_enum"].status)
     end)
 
-    it("falls back to prefix matching for it_requires_* helpers (with random hex suffix)", function()
-      local output =
-        "TissueObservationsControllerTest#test_: update should require authentication - bd6bdc1bd62ef5d7c386a77f.  = 0.05 s = F\n"
-        .. "TissueObservationsControllerTest#test_: update should require authorization - d0544478e23d1b87104cee3e.  = 0.08 s = .\n"
-
-      local results = plugin._parse_test_output(output, {}, {
-        ["TissueObservationsControllerTest#test_: update should require authentication"] = "pos_authn",
-        ["TissueObservationsControllerTest#test_: update should require authorization"] = "pos_authz",
-      })
-
-      assert.equal("failed", results["pos_authn"].status)
-      assert.equal("passed", results["pos_authz"].status)
-    end)
-
     it("maps iteration-generated runtime tests to a single source position via substring fallback", function()
       -- All four runtime tests share the description "apply the additional attributes to
       -- the container" but each has a different context-interpolated chain. The source
@@ -121,27 +107,5 @@ ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
       assert.equal("failed", results["pos_iter"].status)
     end)
 
-    it("marks a single it_requires_all_auth position based on any of its three sub-tests", function()
-      -- All three sub-helpers map to the same pos id; if any fails, the line stays failed.
-      local prefixes = {
-        ["ControllerTest#test_: update should require authentication"] = "pos_all",
-        ["ControllerTest#test_: update should require authorization"] = "pos_all",
-        ["ControllerTest#test_: update should require permission"] = "pos_all",
-      }
-
-      local passing_output =
-        "ControllerTest#test_: update should require authentication - aaa111.  = 0.05 s = .\n"
-        .. "ControllerTest#test_: update should require authorization - bbb222.  = 0.05 s = .\n"
-        .. "ControllerTest#test_: update should require permission - ccc333.  = 0.05 s = .\n"
-      assert.equal("passed", plugin._parse_test_output(passing_output, {}, prefixes)["pos_all"].status)
-
-      -- Mixed: one sub-test fails. The parser must report failed regardless of which
-      -- sub-test fails and where it appears in the output.
-      local mixed_output =
-        "ControllerTest#test_: update should require authentication - aaa111.  = 0.05 s = .\n"
-        .. "ControllerTest#test_: update should require authorization - bbb222.  = 0.05 s = F\n"
-        .. "ControllerTest#test_: update should require permission - ccc333.  = 0.05 s = .\n"
-      assert.equal("failed", plugin._parse_test_output(mixed_output, {}, prefixes)["pos_all"].status)
-    end)
   end)
 end)

--- a/tests/adapter/shoulda_spec.lua
+++ b/tests/adapter/shoulda_spec.lua
@@ -103,6 +103,24 @@ ShouldaTest#test_: addition should add two numbers.  = 0.00 s = .
       assert.equal("passed", results["pos_authz"].status)
     end)
 
+    it("maps iteration-generated runtime tests to a single source position via substring fallback", function()
+      -- All four runtime tests share the description "apply the additional attributes to
+      -- the container" but each has a different context-interpolated chain. The source
+      -- has ONE `should "apply..."` line inside a CardComponent::TYPE_OPTIONS.each loop;
+      -- the substring entry maps all four to it.
+      local output =
+        "CardContainerComponentTest#test_: given a(n) stacking card container with additional attributes should apply the additional attributes to the container.  = 0.01 s = .\n"
+        .. "CardContainerComponentTest#test_: given a(n) inline card container with additional attributes should apply the additional attributes to the container.  = 0.01 s = .\n"
+        .. "CardContainerComponentTest#test_: given a(n) inline_nowrap card container with additional attributes should apply the additional attributes to the container.  = 0.01 s = F\n"
+        .. "CardContainerComponentTest#test_: given a(n) single card container with additional attributes should apply the additional attributes to the container.  = 0.01 s = .\n"
+
+      local substrings = { [" should apply the additional attributes to the container."] = "pos_iter" }
+      local results = plugin._parse_test_output(output, {}, nil, substrings)
+
+      -- "failed sticks": one iteration failed → position is failed.
+      assert.equal("failed", results["pos_iter"].status)
+    end)
+
     it("marks a single it_requires_all_auth position based on any of its three sub-tests", function()
       -- All three sub-helpers map to the same pos id; if any fails, the line stays failed.
       local prefixes = {

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -289,6 +289,24 @@ describe("get_mappings", function()
       prefixes["ControllerTest#test_: update should require authentication"]
     )
   end)
+
+  it("registers three prefix mappings for it_requires_all_auth, all pointing at the same position", function()
+    local tree = Tree.from_list({
+      { id = "ControllerTest", name = "ControllerTest", type = "namespace" },
+      {
+        { id = "ControllerTest_update", name = "update", type = "namespace" },
+        { id = "ControllerTest_all_auth", name = "it_requires_all_auth", type = "test" },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+
+    local _, prefixes = utils.get_mappings(tree)
+
+    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require authentication"])
+    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require authorization"])
+    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require permission"])
+  end)
 end)
 
 describe("shoulda_matcher_prefix", function()
@@ -316,16 +334,27 @@ describe("shoulda_matcher_prefix", function()
   end)
 end)
 
-describe("it_requires_helper_prefix", function()
-  it("derives description from identifier suffix", function()
-    assert.equals("require authentication", utils.it_requires_helper_prefix("it_requires_authentication"))
-    assert.equals("require authorization", utils.it_requires_helper_prefix("it_requires_authorization"))
-    assert.equals("require admin permission", utils.it_requires_helper_prefix("it_requires_admin_permission"))
+describe("it_requires_helper_prefixes", function()
+  it("derives a single description from a simple helper identifier", function()
+    assert.are.same({ "require authentication" }, utils.it_requires_helper_prefixes("it_requires_authentication"))
+    assert.are.same({ "require authorization" }, utils.it_requires_helper_prefixes("it_requires_authorization"))
+    assert.are.same(
+      { "require admin permission" },
+      utils.it_requires_helper_prefixes("it_requires_admin_permission")
+    )
+  end)
+
+  it("expands it_requires_all_auth into its three constituent sub-helpers", function()
+    assert.are.same({
+      "require authentication",
+      "require authorization",
+      "require permission",
+    }, utils.it_requires_helper_prefixes("it_requires_all_auth"))
   end)
 
   it("returns nil for non-helper names", function()
-    assert.is_nil(utils.it_requires_helper_prefix("do a thing"))
-    assert.is_nil(utils.it_requires_helper_prefix("belong_to(:cycle)"))
+    assert.is_nil(utils.it_requires_helper_prefixes("do a thing"))
+    assert.is_nil(utils.it_requires_helper_prefixes("belong_to(:cycle)"))
   end)
 end)
 

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -254,6 +254,79 @@ describe("get_mappings", function()
 
     assert.equals("ShouldaTest_do_a_thing", mappings["ShouldaTest#test_: Shoulda should do a thing."])
   end)
+
+  it("registers a prefix mapping for shoulda-matchers positions", function()
+    local tree = Tree.from_list({
+      { id = "TissueTest", name = "TissueTest", type = "namespace" },
+      {
+        { id = "TissueTest_associations", name = "associations", type = "namespace" },
+        { id = "TissueTest_belong_to_cycle", name = "belong_to(:cycle).optional(true)", type = "test" },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+
+    local _, prefixes = utils.get_mappings(tree)
+
+    assert.equals("TissueTest_belong_to_cycle", prefixes["TissueTest#test_: associations should belong to cycle"])
+  end)
+
+  it("registers a prefix mapping for it_requires_* helpers", function()
+    local tree = Tree.from_list({
+      { id = "ControllerTest", name = "ControllerTest", type = "namespace" },
+      {
+        { id = "ControllerTest_update", name = "update", type = "namespace" },
+        { id = "ControllerTest_it_requires_authentication", name = "it_requires_authentication", type = "test" },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+
+    local _, prefixes = utils.get_mappings(tree)
+
+    assert.equals(
+      "ControllerTest_it_requires_authentication",
+      prefixes["ControllerTest#test_: update should require authentication"]
+    )
+  end)
+end)
+
+describe("shoulda_matcher_prefix", function()
+  it("maps belong_to", function()
+    assert.equals("belong to cycle", utils.shoulda_matcher_prefix("belong_to(:cycle)"))
+    assert.equals("belong to cycle", utils.shoulda_matcher_prefix("belong_to(:cycle).optional(true)"))
+  end)
+
+  it("maps have_many", function()
+    assert.equals(
+      "have many observations",
+      utils.shoulda_matcher_prefix("have_many(:observations).class_name(\"Foo\").dependent(:destroy)")
+    )
+  end)
+
+  it("maps define_enum_for using the colon-prefixed attribute", function()
+    assert.equals(
+      "define :current_disposition",
+      utils.shoulda_matcher_prefix("define_enum_for(:current_disposition).with_values(...)")
+    )
+  end)
+
+  it("returns nil for unknown matchers", function()
+    assert.is_nil(utils.shoulda_matcher_prefix("some_random_matcher(:foo)"))
+  end)
+end)
+
+describe("it_requires_helper_prefix", function()
+  it("derives description from identifier suffix", function()
+    assert.equals("require authentication", utils.it_requires_helper_prefix("it_requires_authentication"))
+    assert.equals("require authorization", utils.it_requires_helper_prefix("it_requires_authorization"))
+    assert.equals("require admin permission", utils.it_requires_helper_prefix("it_requires_admin_permission"))
+  end)
+
+  it("returns nil for non-helper names", function()
+    assert.is_nil(utils.it_requires_helper_prefix("do a thing"))
+    assert.is_nil(utils.it_requires_helper_prefix("belong_to(:cycle)"))
+  end)
 end)
 
 describe("strip_ansi", function()

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -241,6 +241,19 @@ describe("get_mappings", function()
 
     assert.equals("test_id", mappings["test"])
   end)
+
+  it("registers a shoulda-format key for each test", function()
+    local tree = Tree.from_list({
+      { id = "ShouldaTest", name = "ShouldaTest", type = "namespace" },
+      { id = "ShouldaTest_do_a_thing", name = "do a thing", type = "test" },
+    }, function(pos)
+      return pos.id
+    end)
+
+    local mappings = utils.get_mappings(tree)
+
+    assert.equals("ShouldaTest_do_a_thing", mappings["ShouldaTest#test_: Shoulda should do a thing."])
+  end)
 end)
 
 describe("strip_ansi", function()

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -334,6 +334,54 @@ describe("shoulda_matcher_prefix", function()
   end)
 end)
 
+describe("full_shoulda_run_patterns", function()
+  it("returns permissive regex patterns that tolerate module prefixes for class-level shoulds", function()
+    local tree = Tree.from_list({
+      { id = "NoteTemplatesContentControllerTest", name = "NoteTemplatesContentControllerTest", type = "namespace" },
+      { id = "NoteTemplatesContentControllerTest_all_auth", name = "it_requires_all_auth", type = "test" },
+    }, function(pos)
+      return pos.id
+    end)
+
+    local patterns = utils.full_shoulda_run_patterns(tree:children()[1])
+
+    assert.are.same({
+      "NoteTemplatesContentControllerTest.*should require authentication",
+      "NoteTemplatesContentControllerTest.*should require authorization",
+      "NoteTemplatesContentControllerTest.*should require permission",
+    }, patterns)
+  end)
+
+  it("returns a single pattern for a regular matcher", function()
+    local tree = Tree.from_list({
+      { id = "TissueTest", name = "TissueTest", type = "namespace" },
+      {
+        { id = "TissueTest_assoc", name = "associations", type = "namespace" },
+        { id = "TissueTest_belong", name = "belong_to(:cycle)", type = "test" },
+      },
+    }, function(pos)
+      return pos.id
+    end)
+
+    -- Reach the test node: children()[1] is `associations`, then children()[1] of that is `belong_to`.
+    local test_node = tree:children()[1]:children()[1]
+    local patterns = utils.full_shoulda_run_patterns(test_node)
+
+    assert.are.same({ "TissueTest.*should belong to cycle" }, patterns)
+  end)
+
+  it("returns nil for non-matcher non-helper names", function()
+    local tree = Tree.from_list({
+      { id = "Test", name = "Test", type = "namespace" },
+      { id = "test", name = "ordinary string description", type = "test" },
+    }, function(pos)
+      return pos.id
+    end)
+
+    assert.is_nil(utils.full_shoulda_run_patterns(tree:children()[1]))
+  end)
+end)
+
 describe("it_requires_helper_prefixes", function()
   it("derives a single description from a simple helper identifier", function()
     assert.are.same({ "require authentication" }, utils.it_requires_helper_prefixes("it_requires_authentication"))

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -383,6 +383,33 @@ describe("shoulda_matcher_prefix", function()
   end)
 end)
 
+describe("permissive_should_pattern", function()
+  it("returns class.*should name for a class-level string-form should position", function()
+    local tree = Tree.from_list({
+      { id = "ResolverTest", name = "ResolverTest", type = "namespace" },
+      { id = "ResolverTest_raise", name = "raise an error if format is not supported", type = "test" },
+    }, function(pos)
+      return pos.id
+    end)
+
+    assert.equals(
+      "ResolverTest.*should raise an error if format is not supported",
+      utils.permissive_should_pattern(tree:children()[1])
+    )
+  end)
+
+  it("returns nil for namespace positions", function()
+    local tree = Tree.from_list({
+      { id = "ResolverTest", name = "ResolverTest", type = "namespace" },
+      { id = "context", name = "addition", type = "namespace" },
+    }, function(pos)
+      return pos.id
+    end)
+
+    assert.is_nil(utils.permissive_should_pattern(tree))
+  end)
+end)
+
 describe("full_shoulda_run_patterns", function()
   it("returns permissive regex patterns that tolerate module prefixes for class-level shoulds", function()
     local tree = Tree.from_list({

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -329,6 +329,17 @@ describe("shoulda_matcher_prefix", function()
     )
   end)
 
+  it("maps Active Storage attachment matchers", function()
+    assert.equals(
+      "have a has_many_attached called files",
+      utils.shoulda_matcher_prefix("have_many_attached(:files)")
+    )
+    assert.equals(
+      "have a has_one_attached called avatar",
+      utils.shoulda_matcher_prefix("have_one_attached(:avatar)")
+    )
+  end)
+
   it("returns nil for unknown matchers", function()
     assert.is_nil(utils.shoulda_matcher_prefix("some_random_matcher(:foo)"))
   end)

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -329,6 +329,13 @@ describe("shoulda_matcher_prefix", function()
     )
   end)
 
+  it("maps accept_nested_attributes_for to its colon-prefixed form", function()
+    assert.equals(
+      "accepts_nested_attributes_for :service_lines",
+      utils.shoulda_matcher_prefix("accept_nested_attributes_for(:service_lines).allow_destroy(true)")
+    )
+  end)
+
   it("maps Active Storage attachment matchers", function()
     assert.equals(
       "have a has_many_attached called files",

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -336,6 +336,37 @@ describe("shoulda_matcher_prefix", function()
     )
   end)
 
+  it("maps normalize with the attribute name (no colon prefix)", function()
+    assert.equals("normalize npi", utils.shoulda_matcher_prefix("normalize(:npi).from(\" \").to(nil)"))
+    assert.equals("normalize dea", utils.shoulda_matcher_prefix("normalize(:dea).from(\" \").to(nil)"))
+  end)
+
+  it("maps allow_value using the attribute from .for(...) and the literal value", function()
+    assert.equals(
+      "allow :npi to be \xE2\x80\xB9\"1234567890\"\xE2\x80\xBA",
+      utils.shoulda_matcher_prefix("allow_value(\"1234567890\").for(:npi)")
+    )
+    assert.equals(
+      "allow :npi to be \xE2\x80\xB9\"\"\xE2\x80\xBA",
+      utils.shoulda_matcher_prefix("allow_value(\"\").for(:npi)")
+    )
+    assert.equals(
+      "allow :npi to be \xE2\x80\xB9nil\xE2\x80\xBA",
+      utils.shoulda_matcher_prefix("allow_value(nil).for(:npi)")
+    )
+  end)
+
+  it("prepends `not ` to the description when the source name has the should_not marker", function()
+    assert.equals(
+      "not allow :npi to be \xE2\x80\xB9\"123456789\"\xE2\x80\xBA",
+      utils.shoulda_matcher_prefix("not allow_value(\"123456789\").for(:npi)")
+    )
+    assert.equals(
+      "not belong to cycle",
+      utils.shoulda_matcher_prefix("not belong_to(:cycle).optional(true)")
+    )
+  end)
+
   it("maps Active Storage attachment matchers", function()
     assert.equals(
       "have a has_many_attached called files",

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -141,6 +141,46 @@ describe("full_test_name", function()
   end)
 end)
 
+local function fake_node(data, parents)
+  parents = parents or {}
+  local node = {}
+  function node:data() return data end
+  function node:iter_parents()
+    local i = 0
+    return function()
+      i = i + 1
+      return parents[i]
+    end
+  end
+  return node
+end
+
+describe("full_shoulda_test_name", function()
+  it("builds the class-level form using class name minus Test suffix", function()
+    local class_ns = fake_node({ name = "ShouldaTest", type = "namespace" })
+    local test_node = fake_node({ name = "do a thing", type = "test" }, { class_ns })
+
+    assert.equal("ShouldaTest#test_: Shoulda should do a thing.", utils.full_shoulda_test_name(test_node))
+  end)
+
+  it("builds the context-nested form using the context chain", function()
+    local class_ns = fake_node({ name = "ShouldaTest", type = "namespace" })
+    local ctx_ns = fake_node({ name = "addition", type = "namespace" }, { class_ns })
+    local test_node = fake_node({ name = "add two numbers", type = "test" }, { ctx_ns, class_ns })
+
+    assert.equal("ShouldaTest#test_: addition should add two numbers.", utils.full_shoulda_test_name(test_node))
+  end)
+
+  it("joins nested context names with single spaces", function()
+    local class_ns = fake_node({ name = "ShouldaTest", type = "namespace" })
+    local outer = fake_node({ name = "outer", type = "namespace" }, { class_ns })
+    local inner = fake_node({ name = "inner", type = "namespace" }, { outer, class_ns })
+    local test_node = fake_node({ name = "X", type = "test" }, { inner, outer, class_ns })
+
+    assert.equal("ShouldaTest#test_: outer inner should X.", utils.full_shoulda_test_name(test_node))
+  end)
+end)
+
 describe("escaped_full_test_name", function()
   it("escapes # characters", function()
     local tree = Tree.from_list({

--- a/tests/adapter/utils_spec.lua
+++ b/tests/adapter/utils_spec.lua
@@ -271,42 +271,6 @@ describe("get_mappings", function()
     assert.equals("TissueTest_belong_to_cycle", prefixes["TissueTest#test_: associations should belong to cycle"])
   end)
 
-  it("registers a prefix mapping for it_requires_* helpers", function()
-    local tree = Tree.from_list({
-      { id = "ControllerTest", name = "ControllerTest", type = "namespace" },
-      {
-        { id = "ControllerTest_update", name = "update", type = "namespace" },
-        { id = "ControllerTest_it_requires_authentication", name = "it_requires_authentication", type = "test" },
-      },
-    }, function(pos)
-      return pos.id
-    end)
-
-    local _, prefixes = utils.get_mappings(tree)
-
-    assert.equals(
-      "ControllerTest_it_requires_authentication",
-      prefixes["ControllerTest#test_: update should require authentication"]
-    )
-  end)
-
-  it("registers three prefix mappings for it_requires_all_auth, all pointing at the same position", function()
-    local tree = Tree.from_list({
-      { id = "ControllerTest", name = "ControllerTest", type = "namespace" },
-      {
-        { id = "ControllerTest_update", name = "update", type = "namespace" },
-        { id = "ControllerTest_all_auth", name = "it_requires_all_auth", type = "test" },
-      },
-    }, function(pos)
-      return pos.id
-    end)
-
-    local _, prefixes = utils.get_mappings(tree)
-
-    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require authentication"])
-    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require authorization"])
-    assert.equals("ControllerTest_all_auth", prefixes["ControllerTest#test_: update should require permission"])
-  end)
 end)
 
 describe("shoulda_matcher_prefix", function()
@@ -411,24 +375,20 @@ describe("permissive_should_pattern", function()
 end)
 
 describe("full_shoulda_run_patterns", function()
-  it("returns permissive regex patterns that tolerate module prefixes for class-level shoulds", function()
+  it("returns a permissive pattern for a class-level matcher", function()
     local tree = Tree.from_list({
-      { id = "NoteTemplatesContentControllerTest", name = "NoteTemplatesContentControllerTest", type = "namespace" },
-      { id = "NoteTemplatesContentControllerTest_all_auth", name = "it_requires_all_auth", type = "test" },
+      { id = "TissueTest", name = "TissueTest", type = "namespace" },
+      { id = "TissueTest_belong", name = "belong_to(:cycle)", type = "test" },
     }, function(pos)
       return pos.id
     end)
 
     local patterns = utils.full_shoulda_run_patterns(tree:children()[1])
 
-    assert.are.same({
-      "NoteTemplatesContentControllerTest.*should require authentication",
-      "NoteTemplatesContentControllerTest.*should require authorization",
-      "NoteTemplatesContentControllerTest.*should require permission",
-    }, patterns)
+    assert.are.same({ "TissueTest.*should belong to cycle" }, patterns)
   end)
 
-  it("returns a single pattern for a regular matcher", function()
+  it("returns a single pattern for a context-nested matcher", function()
     local tree = Tree.from_list({
       { id = "TissueTest", name = "TissueTest", type = "namespace" },
       {
@@ -439,14 +399,14 @@ describe("full_shoulda_run_patterns", function()
       return pos.id
     end)
 
-    -- Reach the test node: children()[1] is `associations`, then children()[1] of that is `belong_to`.
+    -- children()[1] is `associations`, then children()[1] of that is `belong_to`.
     local test_node = tree:children()[1]:children()[1]
     local patterns = utils.full_shoulda_run_patterns(test_node)
 
     assert.are.same({ "TissueTest.*should belong to cycle" }, patterns)
   end)
 
-  it("returns nil for non-matcher non-helper names", function()
+  it("returns nil for plain string-description positions (non-matcher)", function()
     local tree = Tree.from_list({
       { id = "Test", name = "Test", type = "namespace" },
       { id = "test", name = "ordinary string description", type = "test" },
@@ -455,30 +415,6 @@ describe("full_shoulda_run_patterns", function()
     end)
 
     assert.is_nil(utils.full_shoulda_run_patterns(tree:children()[1]))
-  end)
-end)
-
-describe("it_requires_helper_prefixes", function()
-  it("derives a single description from a simple helper identifier", function()
-    assert.are.same({ "require authentication" }, utils.it_requires_helper_prefixes("it_requires_authentication"))
-    assert.are.same({ "require authorization" }, utils.it_requires_helper_prefixes("it_requires_authorization"))
-    assert.are.same(
-      { "require admin permission" },
-      utils.it_requires_helper_prefixes("it_requires_admin_permission")
-    )
-  end)
-
-  it("expands it_requires_all_auth into its three constituent sub-helpers", function()
-    assert.are.same({
-      "require authentication",
-      "require authorization",
-      "require permission",
-    }, utils.it_requires_helper_prefixes("it_requires_all_auth"))
-  end)
-
-  it("returns nil for non-helper names", function()
-    assert.is_nil(utils.it_requires_helper_prefixes("do a thing"))
-    assert.is_nil(utils.it_requires_helper_prefixes("belong_to(:cycle)"))
   end)
 end)
 

--- a/tests/minitest_examples/shoulda_test.rb
+++ b/tests/minitest_examples/shoulda_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "active_support/test_case"
+require "shoulda/context"
+
+class ShouldaTest < ActiveSupport::TestCase
+  should "do a thing" do
+    assert true
+  end
+
+  context "addition" do
+    should "add two numbers" do
+      assert_equal 2 + 2, 4
+    end
+  end
+end


### PR DESCRIPTION
  So I started using neotest-minitest at work and I was missing a few things — mainly support for should
  "..." blocks from shoulda-context, which a lot of Rails codebases use. I went down the rabbit hole and
  added a few extra support of some extra nomenclature in the tests I saw are also used.

  Putting it all in one PR but I'm happy to split it up if you'd prefer that.

  The big thing: should "..." support

  If you're not familiar, shoulda-context lets you write Minitest tests like:

```ruby
  class FooTest < ActiveSupport::TestCase
    should "do the thing" do
      assert ...
    end

    context "when X" do
      should "do the other thing" do
        assert ...
      end
    end
  end
```

  These were invisible to the plugin before. The PR makes them show up in the summary tree and run
  individually like any other test.

  There's a wrinkle: shoulda-context generates Minitest method names like test_: <context_chain> should
  <description>.  (note the leading test_:, the chain, and the trailing space). So the plugin had to learn
  that naming convention to map results back to positions correctly. Most of the test name plumbing in
  utils.lua is about generating those names and matching them against verbose output.

  The other big thing: should <matcher> from shoulda-matchers

  Once should "string" worked, I realized the same DSL also supports matcher expressions:

```ruby
  should belong_to(:cycle).optional(true)
  should have_many(:items).dependent(:destroy)
  should validate_presence_of(:name)
  should define_enum_for(:status).with_values(...)
  should normalize(:email).from(" ").to(nil)
  should allow_value("hello").for(:greeting)
  should_not allow_value("").for(:greeting)
```

  These are trickier because the runtime test method name depends on each matcher's description method
  (e.g., belong_to(:cycle) → "belong to cycle", define_enum_for(:status) → "define :status"). The PR
  hardcodes the description transforms for the common matchers from shoulda-matchers (belong_to, have_many,
   validate_*, define_enum_for, have_many_attached, have_one_attached, normalize, allow_value,
  accept_nested_attributes_for, plus a handful more). Adding new matchers is a one-line table entry.

  should_not is also supported — detected via the treesitter @func_name capture, marked on the position via
   a custom build_position, and prefixed with "not " when building the runtime description.

  Got these patterns detected and showing in the tree, but then ran into:

  The minitest-reporters problem. The plugin's parser only knew about vanilla minitest's verbose format
  (Class#m = 0.00 s = .). Most real-world Rails projects use the minitest-reporters gem which emits a
  different format (Class#m 0.40 = .). Without this fix the plugin was probably broken for a lot of Rails
  users without anyone noticing. Made the leading = and trailing s optional in the regex.

  The module-prefix problem. For module-scoped test classes (module Foo; class BarTest), shoulda-context
  emits descriptions with the module path baked in. The --name regex the plugin sends to Minitest didn't
  account for this, so individually running these tests reported "0 runs". Fixed by using
  <ShortClass>.*should <description> regex patterns instead of literal prefixes — the .* absorbs whatever
  module prefix shoulda emits.

  The bin/rails test problem. The plugin's dir-mode runner used bundle exec ruby -Itest -e '<require loop>'
   -- file1 file2 .... This works for small directories but deadlocks on bigger Rails apps — the
  require-storm fork-locks against Rails' parallel-test-executor setup before test_helper finishes booting.
   I traced this with ps -p ... -o %cpu and saw a Ruby process sitting at 0% CPU for minutes, just stuck.
  Fixed by detecting bin/rails at the project root and switching to bin/rails test <files> for dir runs in
  Rails projects. Non-Rails projects keep the existing behavior.

  The smaller things

  - Streaming results. Added spec.stream so the summary panel ticks ✓/✗ as tests complete instead of
  waiting for the whole process to exit. Big quality-of-life win for long-running suites.
  - vim.tbl_flatten deprecation. Neovim 0.11 deprecates it; switched to vim.iter():flatten():totable(). Was
   throwing a warning on every test run.
  - Iteration-generated tests. If you write OPTIONS.each do |type|; context "..." do should "X" do end end,
   you get N runtime tests from one source line. Added a substring-fallback mapping so all N map back to
  the single source position (with "failed sticks" aggregation — green only when every iteration passes).
  - A few smaller parser fixes for edge cases I hit (multi-line matcher source breaking the run regex,
  accept_nested_attributes_for description format, gsub-returns-two-values gotcha).

  What I left out

  I had project-specific helpers (it_requires_authentication, it_requires_authorization, etc. —
  class-method DSL on top of shoulda-context that's defined in our test_helper) supported in my fork, but
  those are convention-specific to my codebase and don't belong upstream. They're not in this PR.

Might be a good idea to figure out a way to add support for minitest project specific helpers that is optional and can be added by the users if needed.

  Tests

  Suite went from ~36 tests to 87. New tests cover the matcher prefix transforms, prefix/substring mapping
  logic, parser fallbacks, streaming iterator behavior, and module-prefix tolerance.

  How to try it

  If you've got a Rails project with shoulda-context in the Gemfile, the easiest way to see it in action is
   to open any model test file that uses should "..." or should belong_to(...) — they should now show up in
   the summary panel and individually runnable.

  Happy to revise / split / squash however makes the most sense for you.